### PR TITLE
Experiment for snapshot corruption

### DIFF
--- a/chaos-experiments/kubernetes/scripts/corruptFollowers.sh
+++ b/chaos-experiments/kubernetes/scripts/corruptFollowers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -xoeu pipefail
+
+partition=$1
+
+namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}')
+pod=$(kubectl get pod -n $namespace -l app=$namespace-zeebe -o jsonpath="{.items[0].metadata.name}")
+
+
+# To print the topology in the journal
+kubectl exec $pod -n $namespace -- zbctl status --insecure
+
+partition=$1
+
+
+# determine leader for partition
+state=Leader
+index=$[$(kubectl exec $pod -n $namespace -- zbctl status --insecure \
+  | grep "Partition $partition" \
+  | grep -n "$state" -m 1 \
+  | sed 's/\([0-9]*\).*/\1/') - 1]
+
+podPrefix=$(echo $pod | sed 's/\(.*\)\([0-9]\)$/\1/')
+
+# LEADER for given partition
+leader=$podPrefix$index
+
+# Corrupts snapshots on all followers of given partition
+kubectl get pods -n $namespace \
+  | grep -o -E "$podPrefix[0-9]" \
+  | grep -v $leader \
+  | xargs -I % \
+  sh -c "kubectl cp corruptSnapshot.sh %:/usr/local/zeebe/corrupting.sh; kubectl exec % -- ./corrupting.sh $partition"
+
+
+kubectl exec $pod -- zbctl status --insecure

--- a/chaos-experiments/kubernetes/scripts/corruptSnapshot.sh
+++ b/chaos-experiments/kubernetes/scripts/corruptSnapshot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash 
+set -exo pipefail
+
+
+partition=$1
+
+# Find the latest snapshot directory
+snapshotsPath=data/raft-partition/partitions/$partition/snapshots
+snapshotDir=$(ls -la $snapshotsPath | grep -o -E "([0-9]+-[0-9]+-[0-9]+)")
+
+# Remove a random *.sst file
+fileName=$(ls -la $snapshotsPath/$snapshotDir/ | sort -R | grep -o -m1 -E "[0-9]+\.sst")
+rm $snapshotsPath/$snapshotDir/$fileName

--- a/chaos-experiments/kubernetes/snapshot-corruption/experiment.json
+++ b/chaos-experiments/kubernetes/snapshot-corruption/experiment.json
@@ -1,0 +1,56 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe can recover from corrupted snapshots",
+    "description": "Zeebe should be able to detect and recover from corrupted snapshot",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create workflow instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 60
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Corrupt snapshots on followers",
+            "provider": {
+                "type": "process",
+                "path": "corruptFollowers.sh",
+                "arguments": "3"
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 3",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition-three.sh",
+                "arguments": "Leader"
+            }
+        }
+    ],
+    "rollbacks": []
+}


### PR DESCRIPTION
**Description**
The experiment corrupts the snapshot on followers and restart the leader.
The expectation is that the followers can't become leader and the old leader needs to be become leader again.
After that happen the partition should be healthy again and we can create new instances.

**Experiment**
Run the experiment successfully :tada: 

Output:
```
(chaostk) [zell kubernetes/ ns:zell-chaos]$ chaos run snapshot-corruption/experiment.json 
[2020-04-24 13:33:21 INFO] Validating the experiment's syntax
[2020-04-24 13:33:21 INFO] Experiment looks valid
[2020-04-24 13:33:21 INFO] Running experiment: Zeebe can recover from corrupted snapshots
[2020-04-24 13:33:21 INFO] Steady state hypothesis: Zeebe is alive
[2020-04-24 13:33:21 INFO] Probe: All pods should be ready
[2020-04-24 13:33:22 INFO] Probe: Should be able to create workflow instances on partition 3
[2020-04-24 13:33:24 INFO] Steady state hypothesis is met!
[2020-04-24 13:33:24 INFO] Action: Corrupt snapshots on followers
[2020-04-24 13:33:29 INFO] Action: Terminate leader of partition 3
[2020-04-24 13:33:43 INFO] Steady state hypothesis: Zeebe is alive
[2020-04-24 13:33:43 INFO] Probe: All pods should be ready
[2020-04-24 13:34:22 INFO] Probe: Should be able to create workflow instances on partition 3
[2020-04-24 13:34:25 INFO] Steady state hypothesis is met!
[2020-04-24 13:34:25 INFO] Let's rollback...
[2020-04-24 13:34:25 INFO] No declared rollbacks, let's move on.
[2020-04-24 13:34:25 INFO] Experiment ended with status: completed
```

[chaostoolkit.log](https://github.com/zeebe-io/zeebe-chaos/files/4528595/chaostoolkit.log)
