### PR TITLE
Images are now zoomable

### DIFF
--- a/chaos-days/docusaurus.config.js
+++ b/chaos-days/docusaurus.config.js
@@ -14,6 +14,10 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
   organizationName: 'zeebe-io', // Usually your GitHub org/user name.
   projectName: 'zeebe-chaos', // Usually your repo name.
 
+  plugins: [
+    'plugin-image-zoom'
+  ],
+
   presets: [
     [
       '@docusaurus/preset-classic',
@@ -91,5 +95,6 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      zoomSelector: '.markdown img',
     }),
 });

--- a/chaos-days/node_modules/.package-lock.json
+++ b/chaos-days/node_modules/.package-lock.json
@@ -8700,6 +8700,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/medium-zoom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+      "integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+    },
     "node_modules/memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -9773,6 +9778,13 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/plugin-image-zoom": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "dependencies": {
+        "medium-zoom": "^1.0.4"
       }
     },
     "node_modules/portfinder": {

--- a/chaos-days/package-lock.json
+++ b/chaos-days/package-lock.json
@@ -14,6 +14,7 @@
         "@svgr/webpack": "^5.5.0",
         "clsx": "^1.1.1",
         "file-loader": "^6.2.0",
+        "plugin-image-zoom": "github:ataft/plugin-image-zoom",
         "prism-react-renderer": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -8744,6 +8745,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/medium-zoom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+      "integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+    },
     "node_modules/memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -9823,6 +9829,13 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/plugin-image-zoom": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "dependencies": {
+        "medium-zoom": "^1.0.4"
       }
     },
     "node_modules/portfinder": {
@@ -21687,6 +21700,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "medium-zoom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+      "integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -22485,6 +22503,13 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
+      }
+    },
+    "plugin-image-zoom": {
+      "version": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "from": "plugin-image-zoom@ataft/plugin-image-zoom",
+      "requires": {
+        "medium-zoom": "^1.0.4"
       }
     },
     "portfinder": {

--- a/chaos-days/package.json
+++ b/chaos-days/package.json
@@ -20,6 +20,7 @@
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
+    "plugin-image-zoom": "github:ataft/plugin-image-zoom",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
The images with the charts are quite cool but they are quite small, unless they are opened in a dedicated window.

This makes the images clickable, which will zoom the image in fullscreen.

This uses this plugin: https://github.com/flexanalytics/plugin-image-zoom