### PR TITLE
Fix the documentation build on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Test documentation
+
+on:
+  push:
+    branch:
+      - "*"
+
+jobs:
+  build:
+    name: Build the documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Dependencies
+        run: |
+          cd chaos-days
+          npm ci
+      - name: Build
+        run: |
+          cd chaos-days
+          npm run build

--- a/chaos-days/node_modules/.package-lock.json
+++ b/chaos-days/node_modules/.package-lock.json
@@ -9782,7 +9782,7 @@
     },
     "node_modules/plugin-image-zoom": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "resolved": "https://github.com/flexanalytics/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
       "dependencies": {
         "medium-zoom": "^1.0.4"
       }

--- a/chaos-days/package-lock.json
+++ b/chaos-days/package-lock.json
@@ -14,7 +14,7 @@
         "@svgr/webpack": "^5.5.0",
         "clsx": "^1.1.1",
         "file-loader": "^6.2.0",
-        "plugin-image-zoom": "github:ataft/plugin-image-zoom",
+        "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
         "prism-react-renderer": "^1.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -9833,7 +9833,7 @@
     },
     "node_modules/plugin-image-zoom": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "resolved": "https://github.com/flexanalytics/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
       "dependencies": {
         "medium-zoom": "^1.0.4"
       }
@@ -22506,8 +22506,8 @@
       }
     },
     "plugin-image-zoom": {
-      "version": "git+ssh://git@github.com/ataft/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
-      "from": "plugin-image-zoom@ataft/plugin-image-zoom",
+      "version": "https://github.com/flexanalytics/plugin-image-zoom.git#076a3318689e815e7defd42d572c0854e33ed6ac",
+      "from": "plugin-image-zoom@flexanalytics/plugin-image-zoom",
       "requires": {
         "medium-zoom": "^1.0.4"
       }

--- a/chaos-days/package.json
+++ b/chaos-days/package.json
@@ -20,7 +20,7 @@
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
-    "plugin-image-zoom": "github:ataft/plugin-image-zoom",
+    "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
It tried to access a Git repository (not published on the npm registry) with the git+ssh protocoal, without having a usable SSH key.

This now uses the (unauthenticated) HTTPS protocol.

It also tries to build the project beforehand, which should show the failure earlier.