### PR TITLE
refactor: bundle experiments in jar

### DIFF
--- a/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/ReadChaosExperimentsHandler.kt
+++ b/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/ReadChaosExperimentsHandler.kt
@@ -1,0 +1,70 @@
+package io.zeebe.chaos
+
+import io.camunda.zeebe.client.api.response.ActivatedJob
+import io.camunda.zeebe.client.api.worker.JobClient
+import java.io.File
+import java.nio.file.Files
+
+class ReadChaosExperimentsHandler(private val registerJob : RegisterJob) : ChaosJobHandler {
+
+    companion object {
+        private val LOG =
+            org.slf4j.LoggerFactory.getLogger("io.zeebe.chaos.ReadChaosExperimentsHandler")
+        private const val EXPERIMENT_FILE_NAME = "experiment.json"
+
+        const val JOB_TYPE = "readExperiments"
+    }
+    override fun getJobType(): String {
+        return JOB_TYPE
+    }
+
+    override fun handle(client: JobClient, job: ActivatedJob) {
+        registerJob(job)
+
+        val clusterPlanValue = job.variablesAsMap["clusterPlan"]
+        if (clusterPlanValue == null) {
+            val errorMessage =
+                "Expected to get an valid cluster plan to read the chaos experiments, but got nothing instead."
+            failJob(errorMessage, client, job)
+            return
+        }
+
+        val clusterPlan = clusterPlanValue.toString()
+            .lowercase() // we expected lower case names
+            .replace("\\s".toRegex(), "") // without spaces, like production-m
+
+        LOG.info("Read experiments for cluster plan: $clusterPlan")
+        val clusterPlanExperimentsPath = (this::class.java::getResource)("/chaos-experiments/$clusterPlan")?.path
+        if (clusterPlanExperimentsPath == null) {
+            val errorMessage =
+                "Expected to read chaos experiments for cluster plan '$clusterPlan', but experiments were not found."
+            failJob(errorMessage, client, job)
+            return
+        }
+
+        val clusterPlanDir = File(clusterPlanExperimentsPath)
+        var experiments = listOf<String>()
+        val experimentFiles = clusterPlanDir.listFiles()
+        experimentFiles?.let {
+            experiments =
+                it.filter { file -> file.isDirectory }
+                    .map { Files.readString(File(it, EXPERIMENT_FILE_NAME).toPath()) }
+        }
+
+        client.newCompleteCommand(job.key).variables("{\"experiments\": $experiments}").send()
+    }
+
+    private fun failJob(
+        errorMessage: String,
+        client: JobClient,
+        job: ActivatedJob
+    ) {
+        LOG.warn(errorMessage)
+        client
+            .newFailCommand(job.key)
+            .retries(0)
+            .errorMessage(errorMessage)
+            .send()
+            .join()
+    }
+}

--- a/chaos-workers/chaos-worker/src/main/resources/chaos-experiments
+++ b/chaos-workers/chaos-worker/src/main/resources/chaos-experiments
@@ -1,0 +1,1 @@
+../../../../../chaos-experiments/camunda-cloud/

--- a/chaos-workers/chaos-worker/src/test/kotlin/io/zeebe/chaos/ReadChaosExperimentsHandlerTest.kt
+++ b/chaos-workers/chaos-worker/src/test/kotlin/io/zeebe/chaos/ReadChaosExperimentsHandlerTest.kt
@@ -1,0 +1,176 @@
+package io.zeebe.chaos
+
+import io.camunda.zeebe.client.ZeebeClient
+import io.camunda.zeebe.client.api.worker.JobWorker
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.camunda.zeebe.protocol.record.intent.JobIntent
+import io.camunda.zeebe.protocol.record.value.ErrorType
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.camunda.community.eze.EmbeddedZeebeEngine
+import org.camunda.community.eze.RecordStream.withIntent
+import org.camunda.community.eze.RecordStreamSource
+import org.camunda.community.eze.ZeebeEngine
+import org.junit.After
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@EmbeddedZeebeEngine
+class ReadChaosExperimentsHandlerTest {
+    private lateinit var client: ZeebeClient
+    private lateinit var recordStream: RecordStreamSource
+    private lateinit var worker : JobWorker
+
+    @BeforeEach
+    fun setup() {
+        val bpmnModelInstance =
+            Bpmn
+                .createExecutableProcess("readExperiments")
+                .startEvent()
+                .serviceTask("readExp")
+                { task -> task.zeebeJobType(ReadChaosExperimentsHandler.JOB_TYPE) }
+                .endEvent()
+                .done()
+        client.deployModel(bpmnModelInstance, "readExperiments")
+
+        val readChaosExperimentsHandler =
+            ReadChaosExperimentsHandler{ }
+
+        worker = client
+            .newWorker()
+            .jobType(readChaosExperimentsHandler.getJobType())
+            .handler(readChaosExperimentsHandler)
+            .open()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        worker.close()
+    }
+
+    @Test
+    fun `should fail job on reading experiments without clusterplan`() {
+        // given
+        // when
+        val instance = client.newCreateInstanceCommand()
+            .bpmnProcessId("readExperiments")
+            .latestVersion()
+            .send()
+            .join()
+
+        // then
+        await.alias("should create incident").until {
+            recordStream.incidentRecords()
+                .withProcessInstanceKey(instance.processInstanceKey)
+                .withErrorType(ErrorType.JOB_NO_RETRIES).any()
+        }
+
+        val incident = recordStream.incidentRecords()
+            .withProcessInstanceKey(instance.processInstanceKey)
+            .withErrorType(ErrorType.JOB_NO_RETRIES).first()
+
+        assertThat(incident.value.errorMessage)
+            .isEqualTo("Expected to get an valid cluster plan to read the chaos experiments, but got nothing instead.")
+    }
+
+    @Test
+    fun `should fail job on reading experiments with non-existing clusterplan`() {
+        // given
+        // when
+        val instance = client.newCreateInstanceCommand()
+            .bpmnProcessId("readExperiments")
+            .latestVersion()
+            .variables(mapOf("clusterPlan" to "none"))
+            .send()
+            .join()
+
+        // then
+        await.alias("should create incident").until {
+            recordStream.incidentRecords()
+                .withProcessInstanceKey(instance.processInstanceKey)
+                .withErrorType(ErrorType.JOB_NO_RETRIES).any()
+        }
+
+        val incident = recordStream.incidentRecords()
+            .withProcessInstanceKey(instance.processInstanceKey)
+            .withErrorType(ErrorType.JOB_NO_RETRIES).first()
+
+        assertThat(incident.value.errorMessage)
+            .isEqualTo("Expected to read chaos experiments for cluster plan 'none', but experiments were not found.")
+    }
+
+    @Test
+    fun `should complete job when no experiments exist with existing clusterplan`() {
+        // given
+        // when
+        val instance = client.newCreateInstanceCommand()
+            .bpmnProcessId("readExperiments")
+            .latestVersion()
+            .variables(mapOf("clusterPlan" to "empty"))
+            .send()
+            .join()
+
+        // then
+        await.alias("should complete job").until {
+            recordStream.jobRecords()
+                .withProcessInstanceKey(instance.processInstanceKey)
+                .withIntent(JobIntent.COMPLETED)
+                .any()
+        }
+
+        val completedJob = recordStream.jobRecords()
+            .withProcessInstanceKey(instance.processInstanceKey)
+            .withIntent(JobIntent.COMPLETED)
+            .first()
+
+        val variables = completedJob.value.variables
+
+        assertThat(variables).isNotNull
+        assertThat(variables["experiments"]).isNotNull
+
+        val experiments = variables["experiments"] as List<LinkedHashMap<String, Object>>
+        assertThat(experiments).isEmpty()
+    }
+
+    @Test
+    fun `should read experiments with existing clusterplan`() {
+        // given
+        // when
+        val instance = client.newCreateInstanceCommand()
+            .bpmnProcessId("readExperiments")
+            .latestVersion()
+            .variables(mapOf("clusterPlan" to "Production - M"))
+            .send()
+            .join()
+
+        // then
+        await.alias("should complete job").until {
+            recordStream.jobRecords()
+                .withProcessInstanceKey(instance.processInstanceKey)
+                .withIntent(JobIntent.COMPLETED)
+                .any()
+        }
+
+        val completedJob = recordStream.jobRecords()
+            .withProcessInstanceKey(instance.processInstanceKey)
+            .withIntent(JobIntent.COMPLETED)
+            .first()
+
+        val variables = completedJob.value.variables
+
+        assertThat(variables).isNotNull
+        assertThat(variables["experiments"]).isNotNull
+
+        val experiments = variables["experiments"] as List<LinkedHashMap<String, Object>>
+        assertThat(experiments).isNotEmpty
+        experiments.forEach {
+            assertThat(it["version"]).isNotNull
+            assertThat(it["title"]).isNotNull
+            assertThat(it["description"]).isNotNull
+            assertThat(it["steady-state-hypothesis"]).isNotNull
+            assertThat(it["method"]).isNotNull
+        }
+    }
+}


### PR DESCRIPTION
Previously it was expected that the worker is run in a specific
location where the git repo (zeebe-chaos) is located nearby and
the worker can access the experiments. This meant that we had
to clone on docker build and pull the repository in the
application. This has now changed.

 * The experiments are now symlinked in the resources folder, which caused to copy them into the jar.
 * The job handler can easily access the experiments. The handler code is extracted into an own class.
 * More error handling is added to the job handler. Non existing
   clusterplan or non existing experiments are handled.
 * Add additionaly unit tests for the job handler

closes #78 