### PR TITLE
refactor: resolve worker deployment

### DIFF
--- a/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/WorkerDeploymentFileResolver.kt
+++ b/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/WorkerDeploymentFileResolver.kt
@@ -1,0 +1,16 @@
+package io.zeebe.chaos
+
+import java.io.File
+
+class WorkerDeploymentFileResolverFileResolver {
+
+    fun resolveWorkerDeploymentDir(): File {
+        // In order to resolve it correctly we use the direct path to the file, and return the parent.
+        // This makes sure that the file really exist and can be resolved and doesn't conflict with
+        // the tests, where we have in the test-resources and equal named directory.
+        val workerPath =
+            File(this::class.java.getResource("/chaos-experiments/worker.yaml")!!.path)
+        return workerPath.parentFile
+    }
+
+}

--- a/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
+++ b/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/chaosMain.kt
@@ -13,7 +13,6 @@ import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -166,7 +165,6 @@ private fun createCommandList(
 /**
  * Prepares for running chaos experiments:
  *
- * * Switch the namespace to the target namespace (kubens "$NAMESPACE")
  * * deploy workers for chaos experiments
  *
  * Workers are needed in some of our chaos experiments.
@@ -174,12 +172,10 @@ private fun createCommandList(
  * the logs of the workers AND they are deleted if we delete the namespace anyway.
  * kubectl apply -f worker.yaml &>> "$logFile"
  */
-fun prepareForChaosExperiments(namespace: String) {
+internal fun prepareForChaosExperiments(namespace: String) {
     LOG.info("Prepare chaos experiments.")
 
-    // we should not use kubens when we want to scale our workers, it will change the shared context
-    // runCommands(null, "kubens", namespace)
-    val workerPath = File("$ROOT_PATH/camunda-cloud")
+    val workerPath = WorkerDeploymentFileResolverFileResolver().resolveWorkerDeploymentDir()
     runCommands(workerPath, "kubectl", "--namespace=$namespace", "apply", "--filename=worker.yaml")
 }
 

--- a/chaos-workers/chaos-worker/src/test/kotlin/io/zeebe/chaos/PrepareForChaosExperimentsTest.kt
+++ b/chaos-workers/chaos-worker/src/test/kotlin/io/zeebe/chaos/PrepareForChaosExperimentsTest.kt
@@ -1,0 +1,21 @@
+package io.zeebe.chaos
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PrepareForChaosExperimentsTest {
+
+    @Test
+    fun `should resolve worker deployment from jar`() {
+        // given
+        val fileResolver = WorkerDeploymentFileResolverFileResolver()
+
+        // when
+        val resolveWorkerDeploymentDir = fileResolver.resolveWorkerDeploymentDir()
+
+        // then
+        assertThat(resolveWorkerDeploymentDir).exists()
+        assertThat(resolveWorkerDeploymentDir).isDirectory
+        assertThat(resolveWorkerDeploymentDir.resolve("worker.yaml")).exists().isFile
+    }
+}


### PR DESCRIPTION
Resolve the worker deployment from the jar, instead of relying on the git repo.