### PR TITLE
Set namespace when using helm

### DIFF
--- a/chaos-workers/chaos-experiments/helm/runChaos.sh
+++ b/chaos-workers/chaos-experiments/helm/runChaos.sh
@@ -3,4 +3,5 @@
 source ~/.venvs/chaostk/bin/activate
 
 export CHAOS_SETUP="helm"
+export NAMESPACE=$(kubens -c)
 export PATH="$PATH:$(pwd)/../scripts/"


### PR DESCRIPTION
Without setting the namespace, running any experiment will fail:
```
[2022-01-31 14:13:39 DEBUG] [process:52] Running: ['/home/ole/Source/zeebe-chaos/chaos-workers/chaos-experiments/helm/../scripts/shutdown-gracefully-partition.sh', 'Follower', '3']
[2022-01-31 14:13:39 WARNING] [process:70] This process returned a non-zero exit code. This may indicate some error and not what you expected. Please have a look at the logs.
[2022-01-31 14:13:39 DEBUG] [activity:205]   => succeeded with '{'status': 1, 'stdout': '', 'stderr': '+ source utils.sh\n++ CHAOS_SETUP=helm\n+ state=Follower\n+ partition=3\n++ getNamespace\n/home/ole/Source/zeebe-chaos/chaos-workers/chaos-experiments/helm/../scripts/utils.sh: line 8: NAMESPACE: unbound variable\n+ namespace=\n'}'
```