### PR TITLE
Use right labels for experiments

### DIFF
--- a/chaos-workers/chaos-experiments/scripts/utils.sh
+++ b/chaos-workers/chaos-experiments/scripts/utils.sh
@@ -17,6 +17,7 @@ function getNamespace()
 function getBrokerLabels() {
   if [ "${CHAOS_SETUP}" == "cloud" ]; then
     # For backwards compatability the brokers kept the gateway labels, for a statefulset the labels are not modifiable
+    # To still be able to distinguish the standalone gateway with the broker, the gateway got a new label.
     echo "-l app.kubernetes.io/app=zeebe -l app.kubernetes.io/component=gateway"
   else # helm
     echo "-l app.kubernetes.io/component=zeebe-broker"


### PR DESCRIPTION
The gateway and broker labels have changed for cloud and helm, we need to use the right labels to access the right pods in the experiments, otherwise they will fail.

One important part of this PR is that the brokers in CC SaaS still use the old labels, due to backwards compatability. See for more details here https://github.com/camunda-cloud/zeebe-controller-k8s/pull/701

Furthermore the helm charts are using now also different labels which I tried to apply here as well

 * gateway https://github.com/camunda-community-hub/camunda-cloud-helm/blob/main/charts/ccsm-helm/charts/zeebe-gateway/templates/_helpers.tpl#L26
 * broker https://github.com/camunda-community-hub/camunda-cloud-helm/blob/main/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl#L50