### PR TITLE
fix: verify gateway pods are ready using deployment

### DIFF
--- a/chaos-workers/chaos-experiments/scripts/verify-readiness.sh
+++ b/chaos-workers/chaos-experiments/scripts/verify-readiness.sh
@@ -8,7 +8,13 @@ namespace=$(getNamespace)
 # verify that everything is running
 
 if [ "${CHAOS_SETUP}" == "cloud" ]; then
-  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/app=zeebe --timeout=900s -n "$namespace"
+  # Wait until brokers are ready. The componenet should be broker, but it is wrongly labelled as gateway
+  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/component=gateway --timeout=900s -n "$namespace"
+  # Wait until all gateway pods are running.
+  kubectl wait --for=condition=Available deployment zeebe-gateway --timeout=120s -n "$namespace"
 else
-  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance="$namespace" --timeout=900s -n "$namespace"
+  # Wait until brokers are ready. The componenet should be broker, but it is wrongly labelled as gateway
+  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/component=zeebe-broker --timeout=900s -n "$namespace"
+  # Wait until all gateway pods are running
+  kubectl wait --for=condition=Available deployment $namespace-zeebe-gateway --timeout=120s -n "$namespace"
 fi


### PR DESCRIPTION
We can use the deployment for `kubectl wait`. The check fails if all pods in the deployment are ready.

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/568