### PR TITLE
fix: don't try to use shutdown gateways

### DIFF
--- a/chaos-workers/chaos-experiments/scripts/utils.sh
+++ b/chaos-workers/chaos-experiments/scripts/utils.sh
@@ -61,7 +61,7 @@ function getBroker()
 function getGateway()
 {
   namespace=$(getNamespace)
-  pod=$(kubectl get pod -n "$namespace" $(getGatewayLabels) -o jsonpath="{.items[0].metadata.name}")
+  pod=$(kubectl get pod -n "$namespace" --field-selector status.phase=Running $(getGatewayLabels) -o jsonpath="{.items[0].metadata.name}")
 
   echo "$pod"
 }

--- a/chaos-workers/chaos-experiments/scripts/utils.sh
+++ b/chaos-workers/chaos-experiments/scripts/utils.sh
@@ -38,7 +38,7 @@ function runOnAllBrokers()
 {
   namespace=$(getNamespace)
 
-  pods=$(kubectl get pod -n "$namespace" $(getBrokerLabels) -o jsonpath="{.items[*].metadata.name}")
+  pods=$(kubectl get pod -n "$namespace" "$(getBrokerLabels)" -o jsonpath="{.items[*].metadata.name}")
 
   set +e
   for pod in $pods
@@ -53,7 +53,7 @@ function getBroker()
   index=${1:-0}
 
   namespace=$(getNamespace)
-  pod=$(kubectl get pod -n "$namespace" $(getBrokerLabels) -o jsonpath="{.items[$index].metadata.name}")
+  pod=$(kubectl get pod -n "$namespace" "$(getBrokerLabels)" -o jsonpath="{.items[$index].metadata.name}")
 
   echo "$pod"
 }
@@ -61,7 +61,7 @@ function getBroker()
 function getGateway()
 {
   namespace=$(getNamespace)
-  pod=$(kubectl get pod -n "$namespace" --field-selector status.phase=Running $(getGatewayLabels) -o jsonpath="{.items[0].metadata.name}")
+  pod=$(kubectl get pod -n "$namespace" --field-selector status.phase=Running "$(getGatewayLabels)" -o jsonpath="{.items[0].metadata.name}")
 
   echo "$pod"
 }

--- a/chaos-workers/chaos-experiments/scripts/utils.sh
+++ b/chaos-workers/chaos-experiments/scripts/utils.sh
@@ -38,7 +38,9 @@ function runOnAllBrokers()
 {
   namespace=$(getNamespace)
 
-  pods=$(kubectl get pod -n "$namespace" "$(getBrokerLabels)" -o jsonpath="{.items[*].metadata.name}")
+  # disable word splitting check, word splitting is necessary for broker labels
+  # shellcheck disable=SC2046
+  pods=$(kubectl get pod -n "$namespace" $(getBrokerLabels) -o jsonpath="{.items[*].metadata.name}")
 
   set +e
   for pod in $pods
@@ -53,7 +55,9 @@ function getBroker()
   index=${1:-0}
 
   namespace=$(getNamespace)
-  pod=$(kubectl get pod -n "$namespace" "$(getBrokerLabels)" -o jsonpath="{.items[$index].metadata.name}")
+  # disable word splitting check, word splitting is necessary for broker labels
+  # shellcheck disable=SC2046
+  pod=$(kubectl get pod -n "$namespace" $(getBrokerLabels) -o jsonpath="{.items[$index].metadata.name}")
 
   echo "$pod"
 }
@@ -61,7 +65,9 @@ function getBroker()
 function getGateway()
 {
   namespace=$(getNamespace)
-  pod=$(kubectl get pod -n "$namespace" --field-selector status.phase=Running "$(getGatewayLabels)" -o jsonpath="{.items[0].metadata.name}")
+  # disable word splitting check, word splitting is necessary for gateway labels
+  # shellcheck disable=SC2046
+  pod=$(kubectl get pod -n "$namespace" --field-selector status.phase=Running $(getGatewayLabels) -o jsonpath="{.items[0].metadata.name}")
 
   echo "$pod"
 }

--- a/chaos-workers/chaos-experiments/scripts/verify-readiness.sh
+++ b/chaos-workers/chaos-experiments/scripts/verify-readiness.sh
@@ -20,5 +20,5 @@ else
   # Wait until all gateway pods are running. We cannot use `--for=condition=Ready` pod for gateway because
   # this check also includes the evicted pods as long as they are not deleted. Evicted pods are not immediately
   # deleted by kuberenetes. The following check passes only if all pods are running, and excludes evicted pods.
-  kubectl wait --for=condition=Available deployment $namespace-zeebe-gateway --timeout=120s -n "$namespace"
+  kubectl wait --for=condition=Available deployment "$namespace-zeebe-gateway" --timeout=120s -n "$namespace"
 fi


### PR DESCRIPTION
When gateway pods are evicted, they stay around with status "Shutdown".
We need to filter for running pods to get a gateway that we can actually use.