### PR TITLE
Publish message on specific partition

### DIFF
--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
@@ -57,7 +58,7 @@ var publishCmd = &cobra.Command{
 			fmt.Printf("Send message with correaltion key '%s' (ASCII: %d) \n", correlationKey, int(correlationKey[0]))
 		}
 
-		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).Send(context.TODO())
+		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
 		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
 
 		if Verbose {

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -59,9 +59,7 @@ var publishCmd = &cobra.Command{
 		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
 		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
 
-		if Verbose {
-			fmt.Printf("Message was sent and returned key %d, which corresponds to partition: %d\n", messageResponse.Key, partitionIdFromKey)
-		}
+		fmt.Printf("Message was sent and returned key %d, which corresponds to partition: %d\n", messageResponse.Key, partitionIdFromKey)
 	},
 }
 

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -25,6 +25,7 @@ import (
 func init() {
 	rootCmd.AddCommand(publishCmd)
 	publishCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
+	publishCmd.Flags().StringVar(&msgName, "msgName", "msg", "Specify the name of the message, which should be published.")
 }
 
 var publishCmd = &cobra.Command{
@@ -56,7 +57,7 @@ var publishCmd = &cobra.Command{
 			fmt.Printf("Send message with correaltion key '%s' (ASCII: %d) \n", correlationKey, int(correlationKey[0]))
 		}
 
-		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName("test").CorrelationKey(correlationKey).Send(context.TODO())
+		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).Send(context.TODO())
 		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
 
 		if Verbose {

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -53,7 +53,7 @@ var publishCmd = &cobra.Command{
 		panicOnError(err)
 
 		if Verbose {
-			fmt.Printf("Send message with correaltion key '%s' (ASCII: %d) \n", correlationKey, int(correlationKey[0]))
+			fmt.Printf("Send message '%s', with correaltion key '%s' (ASCII: %d) \n", msgName, correlationKey, int(correlationKey[0]))
 		}
 
 		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
+)
+
+func init() {
+	rootCmd.AddCommand(publishCmd)
+	publishCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
+}
+
+var publishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Publish a message",
+	Long:  `Publish a message to a certain partition.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		k8Client, err := internal.CreateK8Client()
+		if err != nil {
+			panic(err)
+		}
+
+		port := 26500
+		closeFn, err := k8Client.GatewayPortForward(port)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer closeFn()
+
+		zbClient, err := internal.CreateZeebeClient(port)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer zbClient.Close()
+
+		correlationKey := internal.FindCorrelationKeyForPartition(partitionId)
+
+		if Verbose {
+			fmt.Printf("Send message with correaltion key '%s' (ASCII: %d) \n", correlationKey, int(correlationKey[0]))
+		}
+
+		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName("test").CorrelationKey(correlationKey).Send(context.TODO())
+		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
+
+		if Verbose {
+			fmt.Printf("Message was sent and returned key %d, which corresponds to partition: %d\n", messageResponse.Key, partitionIdFromKey)
+		}
+	},
+}

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -26,6 +26,7 @@ var (
 	partitionId        int
 	role               string
 	nodeId             int
+	msgName            string
 	broker1PartitionId int
 	broker1Role        string
 	broker1NodeId      int

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -233,7 +233,7 @@ func FindCorrelationKeyForPartition(expectedPartition int, partitionsCount int) 
 	// hashcode = i ( 48 >= i >= 126) == ASCII CODE
 	//
 	for hashcode := 48; hashcode < 127; hashcode++ {
-		if expectedPartition == (( hashcode % partitionsCount) + 1) {
+		if expectedPartition == ((hashcode % partitionsCount) + 1) {
 			return string(rune(hashcode)), nil
 		}
 	}

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -189,7 +189,7 @@ func ExtractPartitionIdFromKey(key int64) int32 {
 }
 
 func FindCorrelationKeyForPartition(expectedPartition int, partitionsCount int) (string, error) {
-	if expectedPartition >= partitionsCount {
+	if expectedPartition > partitionsCount { // partition ids start at 1
 		return "", errors.New(fmt.Sprintf("expected partition (%d) must be smaller than partitionsCount (%d)", expectedPartition, partitionsCount))
 	}
 

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -247,13 +247,41 @@ func Test_ShouldFindCorrelationKeyForPartition(t *testing.T) {
 	partitionCount := 49
 
 	// when
-	correlationKeyForPartition := FindCorrelationKeyForPartition(expectedPartition)
+	correlationKeyForPartition, err := FindCorrelationKeyForPartition(expectedPartition, partitionCount)
 
 	// then
+	assert.NoError(t, err)
 	hashCode := getSubscriptionHashCode(correlationKeyForPartition)
 	actualPartition := (hashCode % partitionCount) + 1
 
 	assert.Equal(t, expectedPartition, actualPartition, "The partitions should be equal")
+}
+
+func Test_ShouldFailToFindCorrelationKeyForPartition(t *testing.T) {
+	// given
+	expectedPartition := 47
+	// this function only works if the count is larger than the expected partition
+	partitionCount := 149
+
+	// when
+	_, err := FindCorrelationKeyForPartition(expectedPartition, partitionCount)
+
+	// then
+	assert.Error(t, err, "Expect error for too large partitionCount")
+	assert.Contains(t, err.Error(), "must not exceed 78 partitions.")
+}
+
+func Test_ShouldFailIfExpectedPartitionIsLargenThanCount(t *testing.T) {
+	// given
+	expectedPartition := 47
+	partitionCount := 3
+
+	// when
+	_, err := FindCorrelationKeyForPartition(expectedPartition, partitionCount)
+
+	// then
+	assert.Error(t, err, "Expect error for too small partitionCount")
+	assert.Contains(t, err.Error(), "must be smaller than partitionsCount")
 }
 
 func getSubscriptionHashCode(correlationKey string) int {

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -239,3 +239,27 @@ func Test_ShouldSucceedOnCorrectPartition(t *testing.T) {
 	// then
 	assert.NoError(t, err, "expected no error")
 }
+
+func Test_ShouldFindCorrelationKeyForPartition(t *testing.T) {
+	// given
+	expectedPartition := 47
+	// this function only works if the count is larger then the expected partition
+	partitionCount := 49
+
+	// when
+	correlationKeyForPartition := FindCorrelationKeyForPartition(expectedPartition)
+
+	// then
+	hashCode := getSubscriptionHashCode(correlationKeyForPartition)
+	actualPartition := (hashCode % partitionCount) + 1
+
+	assert.Equal(t, expectedPartition, actualPartition, "The partitions should be equal")
+}
+
+func getSubscriptionHashCode(correlationKey string) int {
+	hashCode := 0
+	for i := 0; i < len(correlationKey); i++ {
+		hashCode = 31*hashCode + int(correlationKey[i])
+	}
+	return hashCode
+}

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -257,6 +257,22 @@ func Test_ShouldFindCorrelationKeyForPartition(t *testing.T) {
 	assert.Equal(t, expectedPartition, actualPartition, "The partitions should be equal")
 }
 
+func Test_ShouldFindCorrelationKeyForPartitionWhichIsEqualToCount(t *testing.T) {
+	// given
+	expectedPartition := 3
+	partitionCount := 3
+
+	// when
+	correlationKeyForPartition, err := FindCorrelationKeyForPartition(expectedPartition, partitionCount)
+
+	// then
+	assert.NoError(t, err)
+	hashCode := getSubscriptionHashCode(correlationKeyForPartition)
+	actualPartition := (hashCode % partitionCount) + 1
+
+	assert.Equal(t, expectedPartition, actualPartition, "The partitions should be equal")
+}
+
 func Test_ShouldFailToFindCorrelationKeyForPartition(t *testing.T) {
 	// given
 	expectedPartition := 47


### PR DESCRIPTION
Adds a new feature to publish a message with a printable correlation key to an specific (given) partition. This is useful if we want to experiment with message correlation, for example disconnect certain partitions etc.


```go
// The message publish partition distribution is based
// on the following hashcode and modulo by the partition count
//
// Since this calculation is used not only on publish, but also for
// opening the message and instance subscriptions we must support for
// backwards compatibility, otherwise message will not be correlated
//
// This allows us to make certain assumptions, and shortcuts.
//
// static int getSubscriptionHashCode(final DirectBuffer correlationKey) {
//   is equal to java.lang.String#hashCode
//   int hashCode = 0;
//
//   for (int i = 0, length = correlationKey.capacity(); i < length; i++) {
//      	hashCode = 31 * hashCode + correlationKey.getByte(i);
//   }
//   return hashCode;
// }
//
// and
//   public static int getSubscriptionPartitionId(
//      final DirectBuffer correlationKey, final int partitionCount) {
//    final int hashCode = getSubscriptionHashCode(correlationKey);
//    // partition ids range from START_PARTITION_ID .. START_PARTITION_ID + partitionCount
//    return Math.abs(hashCode % partitionCount) + START_PARTITION_ID;
//  }
// Based on the hash code function, we now that if the string has a length of one byte
// no multiplication will happen.
//
// Since we need a printable (for variables) character we start with ASCII code 48, until 126.
// Formulas:
//
// expectedPartition = (hashcode mod partitionCount) + partitionStartId
// hashcode = i ( 48 >= i >= 126) == ASCII CODE
//
```

# Usage

```sh
$ ./zbchaos publish -v --partitionId 1
Connecting to zell-chaos
Successfully created port forwarding tunnel
Send message 'msg', with correaltion key '0' (ASCII: 48) 
Message was sent and returned key 2251799813685346, which corresponds to partition: 1
```