### PR TITLE
Allow to specify other process models

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -26,6 +26,7 @@ var (
 	partitionId        int
 	role               string
 	nodeId             int
+	processModelPath   string
 	broker1PartitionId int
 	broker1Role        string
 	broker1NodeId      int

--- a/go-chaos/cmd/verify.go
+++ b/go-chaos/cmd/verify.go
@@ -28,7 +28,9 @@ func init() {
 	rootCmd.AddCommand(verifyCmd)
 	verifyCmd.AddCommand(verifyReadinessCmd)
 	verifyCmd.AddCommand(verifySteadyStateCmd)
+
 	verifySteadyStateCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
+	verifySteadyStateCmd.Flags().StringVar(&processModelPath, "processModelPath", "", "Specify the path to a BPMN process model, which should be deployed and an instance should be created of.")
 }
 
 var verifyCmd = &cobra.Command{
@@ -81,7 +83,7 @@ A process model will be deployed and process instances are created until the req
 		}
 		defer zbClient.Close()
 
-		err = internal.DeployModel(zbClient)
+		err = internal.DeployModel(zbClient, processModelPath)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -238,4 +239,35 @@ func Test_ShouldSucceedOnCorrectPartition(t *testing.T) {
 
 	// then
 	assert.NoError(t, err, "expected no error")
+}
+
+func Test_ShouldReadDefaultFile(t *testing.T) {
+	// given
+	fileName := ""
+	expectedBytes, err := bpmnContent.ReadFile("bpmn/one_task.bpmn")
+	assert.NoError(t, err)
+
+	// when
+	defaultFileBytes, err := readBPMNFileOrDefault(fileName)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, defaultFileBytes)
+}
+
+func Test_ShouldReadGivenFile(t *testing.T) {
+	// given
+	fileName := "somefile.txt"
+	expectedBytes := []byte("content")
+	err := os.WriteFile(fileName, expectedBytes, 0644)
+	assert.NoError(t, err)
+
+	// when
+	fileBytes, err := readBPMNFileOrDefault(fileName)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, fileBytes)
+	err = os.RemoveAll(fileName)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION


This feature allows specifying different process models for the `verify steady-state` command. This is useful for other experiments, for example where I want to deploy a model with a message catch event.