### PR TITLE
Make message chaos experiment possible

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -26,7 +26,6 @@ var (
 	partitionId        int
 	role               string
 	nodeId             int
-	msgName            string
 	processModelPath   string
 	variables          string
 	msgName            string

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	nodeId             int
 	msgName            string
 	processModelPath   string
+	variables          string
 	msgName            string
 	broker1PartitionId int
 	broker1Role        string

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	nodeId             int
 	msgName            string
 	processModelPath   string
+	msgName            string
 	broker1PartitionId int
 	broker1Role        string
 	broker1NodeId      int

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -27,6 +27,7 @@ var (
 	role               string
 	nodeId             int
 	msgName            string
+	processModelPath   string
 	broker1PartitionId int
 	broker1Role        string
 	broker1NodeId      int

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -30,6 +30,7 @@ var (
 	processModelPath   string
 	variables          string
 	msgName            string
+	awaitResult        bool
 	broker1PartitionId int
 	broker1Role        string
 	broker1NodeId      int

--- a/go-chaos/cmd/verify.go
+++ b/go-chaos/cmd/verify.go
@@ -28,7 +28,9 @@ func init() {
 	rootCmd.AddCommand(verifyCmd)
 	verifyCmd.AddCommand(verifyReadinessCmd)
 	verifyCmd.AddCommand(verifySteadyStateCmd)
+
 	verifySteadyStateCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
+	verifySteadyStateCmd.Flags().StringVar(&processModelPath, "processModelPath", "", "Specify the path to a BPMN process model, which should be deployed and an instance should be created of.")
 }
 
 var verifyCmd = &cobra.Command{
@@ -81,7 +83,7 @@ A process model will be deployed and process instances are created until the req
 		}
 		defer zbClient.Close()
 
-		err = internal.DeployModel(zbClient)
+		err = internal.DeployModel(zbClient, processModelPath)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/go-chaos/cmd/verify.go
+++ b/go-chaos/cmd/verify.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
@@ -32,6 +32,7 @@ func init() {
 	verifySteadyStateCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
 	verifySteadyStateCmd.Flags().StringVar(&processModelPath, "processModelPath", "", "Specify the path to a BPMN process model, which should be deployed and an instance should be created of.")
 	verifySteadyStateCmd.Flags().StringVar(&variables, "variables", "", "Specify the variables for the process instance. Expect json string.")
+	verifySteadyStateCmd.Flags().BoolVar(&awaitResult, "awaitResult", false, "Specify whether the completion of the created process instance should be awaited.")
 }
 
 var verifyCmd = &cobra.Command{
@@ -84,20 +85,13 @@ A process model will be deployed and process instances are created until the req
 		}
 		defer zbClient.Close()
 
-		err = internal.DeployModel(zbClient, processModelPath)
+		processDefinitionKey, err := internal.DeployModel(zbClient, processModelPath)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		err = internal.CreateProcessInstanceOnPartition(func(processName string) (*pb.CreateProcessInstanceResponse, error) {
-			commandStep3 := zbClient.NewCreateInstanceCommand().BPMNProcessId(processName).LatestVersion()
-			if len(variables) != 0 {
-				_, err := commandStep3.VariablesFromString(variables)
-				if err != nil {
-					return nil, err
-				}
-			}
-			return commandStep3.Send(context.TODO())
+		err = internal.CreateProcessInstanceOnPartition(func() (int64, error) {
+			return createInstance(zbClient, processDefinitionKey)
 		}, int32(partitionId), 30*time.Second)
 		if err != nil {
 			panic(err.Error())
@@ -105,4 +99,30 @@ A process model will be deployed and process instances are created until the req
 
 		fmt.Printf("The steady-state was successfully verified!\n")
 	},
+}
+
+func createInstance(zbClient zbc.Client, processDefinitionKey int64) (int64, error) {
+	if Verbose {
+		fmt.Printf("Create process instance with defition key %d [variables: '%s', awaitResult: %t]\n", processDefinitionKey, variables, awaitResult)
+	}
+
+	commandStep3 := zbClient.NewCreateInstanceCommand().ProcessDefinitionKey(processDefinitionKey)
+	if len(variables) != 0 {
+		_, err := commandStep3.VariablesFromString(variables)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if awaitResult {
+		instanceWithResultResponse, err := commandStep3.WithResult().Send(context.TODO())
+		if err != nil {
+			return 0, err
+		}
+		return instanceWithResultResponse.ProcessInstanceKey, nil
+	}
+	instanceResponse, err := commandStep3.Send(context.TODO())
+	if err != nil {
+		return 0, err
+	}
+	return instanceResponse.ProcessInstanceKey, nil
 }

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -136,9 +136,13 @@ func extractNodeId(topologyResponse *pb.TopologyResponse, partitionId int, role 
 var bpmnContent embed.FS
 
 func DeployModel(client zbc.Client, fileName string) error {
-	bpmnBytes, err := readBPMNFileOrDefault(fileName)
+	bpmnBytes, fileName, err := readBPMNFileOrDefault(fileName)
 	if err != nil {
 		return err
+	}
+
+	if Verbosity {
+		fmt.Printf("Deploy file %s (size: %d bytes).\n", fileName, len(bpmnBytes))
 	}
 
 	response, err := client.NewDeployProcessCommand().AddResource(bpmnBytes, fileName).Send(context.TODO())
@@ -153,7 +157,7 @@ func DeployModel(client zbc.Client, fileName string) error {
 }
 
 // if file not exist we read our default BPMN process model and return the content
-func readBPMNFileOrDefault(fileName string) ([]byte, error) {
+func readBPMNFileOrDefault(fileName string) ([]byte, string, error) {
 	var bpmnBytes []byte
 	var err error
 
@@ -162,16 +166,16 @@ func readBPMNFileOrDefault(fileName string) ([]byte, error) {
 
 		bpmnBytes, err = bpmnContent.ReadFile(fileName)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	} else {
 		bpmnBytes, err = os.ReadFile(fileName)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
 
-	return bpmnBytes, nil
+	return bpmnBytes, fileName, nil
 }
 
 type ProcessInstanceCreator func(processName string) (*pb.CreateProcessInstanceResponse, error)

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -215,7 +215,7 @@ func ExtractPartitionIdFromKey(key int64) int32 {
 }
 
 func FindCorrelationKeyForPartition(expectedPartition int, partitionsCount int) (string, error) {
-	if expectedPartition > partitionsCount { // partition ids start at 1
+	if expectedPartition >= partitionsCount {
 		return "", errors.New(fmt.Sprintf("expected partition (%d) must be smaller than partitionsCount (%d)", expectedPartition, partitionsCount))
 	}
 

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -19,6 +19,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
@@ -134,23 +135,43 @@ func extractNodeId(topologyResponse *pb.TopologyResponse, partitionId int, role 
 //go:embed bpmn/*
 var bpmnContent embed.FS
 
-func DeployModel(client zbc.Client) error {
-
-	processModelFileName := "bpmn/one_task.bpmn"
-	bpmnBytes, err := bpmnContent.ReadFile(processModelFileName)
+func DeployModel(client zbc.Client, fileName string) error {
+	bpmnBytes, err := readBPMNFileOrDefault(fileName)
 	if err != nil {
 		return err
 	}
 
-	response, err := client.NewDeployProcessCommand().AddResource(bpmnBytes, processModelFileName).Send(context.TODO())
+	response, err := client.NewDeployProcessCommand().AddResource(bpmnBytes, fileName).Send(context.TODO())
 	if err != nil {
 		return err
 	}
 
 	if Verbosity {
-		fmt.Printf("Deployed process model %s successful with key %d.\n", processModelFileName, response.Processes[0].ProcessDefinitionKey)
+		fmt.Printf("Deployed process model %s successful with key %d.\n", fileName, response.Processes[0].ProcessDefinitionKey)
 	}
 	return nil
+}
+
+// if file not exist we read our default BPMN process model and return the content
+func readBPMNFileOrDefault(fileName string) ([]byte, error) {
+	var bpmnBytes []byte
+	var err error
+
+	if len(fileName) == 0 {
+		fileName = "bpmn/one_task.bpmn"
+
+		bpmnBytes, err = bpmnContent.ReadFile(fileName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bpmnBytes, err = os.ReadFile(fileName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return bpmnBytes, nil
 }
 
 type ProcessInstanceCreator func(processName string) (*pb.CreateProcessInstanceResponse, error)

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -135,10 +135,10 @@ func extractNodeId(topologyResponse *pb.TopologyResponse, partitionId int, role 
 //go:embed bpmn/*
 var bpmnContent embed.FS
 
-func DeployModel(client zbc.Client, fileName string) error {
+func DeployModel(client zbc.Client, fileName string) (int64, error) {
 	bpmnBytes, fileName, err := readBPMNFileOrDefault(fileName)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if Verbosity {
@@ -147,13 +147,14 @@ func DeployModel(client zbc.Client, fileName string) error {
 
 	response, err := client.NewDeployProcessCommand().AddResource(bpmnBytes, fileName).Send(context.TODO())
 	if err != nil {
-		return err
+		return 0, err
 	}
 
+	processDefinitionKey := response.Processes[0].ProcessDefinitionKey
 	if Verbosity {
-		fmt.Printf("Deployed process model %s successful with key %d.\n", fileName, response.Processes[0].ProcessDefinitionKey)
+		fmt.Printf("Deployed process model %s successful with key %d.\n", fileName, processDefinitionKey)
 	}
-	return nil
+	return processDefinitionKey, nil
 }
 
 // if file not exist we read our default BPMN process model and return the content

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -306,4 +307,35 @@ func getSubscriptionHashCode(correlationKey string) int {
 		hashCode = 31*hashCode + int(correlationKey[i])
 	}
 	return hashCode
+}
+
+func Test_ShouldReadDefaultFile(t *testing.T) {
+	// given
+	fileName := ""
+	expectedBytes, err := bpmnContent.ReadFile("bpmn/one_task.bpmn")
+	assert.NoError(t, err)
+
+	// when
+	defaultFileBytes, err := readBPMNFileOrDefault(fileName)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, defaultFileBytes)
+}
+
+func Test_ShouldReadGivenFile(t *testing.T) {
+	// given
+	fileName := "somefile.txt"
+	expectedBytes := []byte("content")
+	err := os.WriteFile(fileName, expectedBytes, 0644)
+	assert.NoError(t, err)
+
+	// when
+	fileBytes, err := readBPMNFileOrDefault(fileName)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, fileBytes)
+	err = os.RemoveAll(fileName)
+	assert.NoError(t, err)
 }

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -146,10 +146,8 @@ func Test_ExtractPartitionId(t *testing.T) {
 
 func Test_ShouldTimeoutIfProcessInstanceWasNotCreatedOnRequiredPartition(t *testing.T) {
 	// given
-	dummyCreator := func(processName string) (*pb.CreateProcessInstanceResponse, error) {
-		return &pb.CreateProcessInstanceResponse{
-			ProcessInstanceKey: 6755399441055751,
-		}, nil
+	dummyCreator := func() (int64, error) {
+		return 6755399441055751, nil
 	}
 
 	// when
@@ -162,10 +160,8 @@ func Test_ShouldTimeoutIfProcessInstanceWasNotCreatedOnRequiredPartition(t *test
 
 func Test_ShouldImmediatelyTimeout(t *testing.T) {
 	// given
-	dummyCreator := func(processName string) (*pb.CreateProcessInstanceResponse, error) {
-		return &pb.CreateProcessInstanceResponse{
-			ProcessInstanceKey: 6755399441055751,
-		}, nil
+	dummyCreator := func() (int64, error) {
+		return 6755399441055751, nil
 	}
 
 	// when
@@ -179,14 +175,12 @@ func Test_ShouldImmediatelyTimeout(t *testing.T) {
 func Test_ShouldRetryOnProcessInstanceCreationError(t *testing.T) {
 	// given
 	counter := 1
-	dummyCreator := func(processName string) (*pb.CreateProcessInstanceResponse, error) {
+	dummyCreator := func() (int64, error) {
 		if counter == 3 {
-			return &pb.CreateProcessInstanceResponse{
-				ProcessInstanceKey: 2251799813685279,
-			}, nil
+			return 2251799813685279, nil
 		}
 		counter++
-		return nil, errors.New("foo")
+		return 0, errors.New("foo")
 	}
 
 	// when
@@ -199,24 +193,18 @@ func Test_ShouldRetryOnProcessInstanceCreationError(t *testing.T) {
 func Test_ShouldRetryOnProcessInstanceCreationErrorAndWrongPartitionId(t *testing.T) {
 	// given
 	counter := 0
-	dummyCreator := func(processName string) (*pb.CreateProcessInstanceResponse, error) {
+	dummyCreator := func() (int64, error) {
 		counter++
 		if counter == 1 {
-			return &pb.CreateProcessInstanceResponse{
-				ProcessInstanceKey: 4503599627370515,
-			}, nil
+			return 4503599627370515, nil
 		}
 		if counter == 2 {
-			return &pb.CreateProcessInstanceResponse{
-				ProcessInstanceKey: 2251799813685279,
-			}, nil
+			return 2251799813685279, nil
 		}
 		if counter == 4 {
-			return &pb.CreateProcessInstanceResponse{
-				ProcessInstanceKey: 6755399441055757,
-			}, nil
+			return 6755399441055757, nil
 		}
-		return nil, errors.New("foo")
+		return 0, errors.New("foo")
 	}
 
 	// when
@@ -228,10 +216,8 @@ func Test_ShouldRetryOnProcessInstanceCreationErrorAndWrongPartitionId(t *testin
 
 func Test_ShouldSucceedOnCorrectPartition(t *testing.T) {
 	// given
-	dummyCreator := func(processName string) (*pb.CreateProcessInstanceResponse, error) {
-		return &pb.CreateProcessInstanceResponse{
-			ProcessInstanceKey: 4503599627370515,
-		}, nil
+	dummyCreator := func() (int64, error) {
+		return 4503599627370515, nil
 	}
 
 	// when

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -316,10 +316,11 @@ func Test_ShouldReadDefaultFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// when
-	defaultFileBytes, err := readBPMNFileOrDefault(fileName)
+	defaultFileBytes, defaultFileName, err := readBPMNFileOrDefault(fileName)
 
 	// then
 	assert.NoError(t, err)
+	assert.Equal(t, "bpmn/one_task.bpmn", defaultFileName)
 	assert.Equal(t, expectedBytes, defaultFileBytes)
 }
 
@@ -331,10 +332,11 @@ func Test_ShouldReadGivenFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// when
-	fileBytes, err := readBPMNFileOrDefault(fileName)
+	fileBytes, actualFileName, err := readBPMNFileOrDefault(fileName)
 
 	// then
 	assert.NoError(t, err)
+	assert.Equal(t, "somefile.txt", actualFileName)
 	assert.Equal(t, expectedBytes, fileBytes)
 	err = os.RemoveAll(fileName)
 	assert.NoError(t, err)


### PR DESCRIPTION
Before my surgery I run a new message correlation experiment, details you can find in the blog https://zeebe-io.github.io/zeebe-chaos/2022/08/31/Message-Correlation-after-Network-Partition For that experiment I had to add some new features to the zbchaos toolkit

I already opened some PR's #166 #167 but this was only part of it, so now here is everything I added to make this experiment possible.

* Allow specifying different process models for the verify steady-state command. This is useful for other experiments, for example where I want to deploy a model with a message catch event.
* Allow to specify the message name
* Allow to specify variables on the process instance creation
* Iterate over the message publish correlation key, we use now printable characters otherwise they cant be used in variables


