### PR TITLE
feat: deployment manifests for zbchaos worker

### DIFF
--- a/.github/workflows/publishZbchaosImage.yml
+++ b/.github/workflows/publishZbchaosImage.yml
@@ -7,10 +7,33 @@ on:
 jobs:
   publish-image:
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ github.event.release.name || github.sha }}
     steps:
       - uses: actions/checkout@v3
+      - name: Collect image tags
+        uses: actions/github-script@v6
+        id: image-tags
+        with:
+          # language=javascript
+          script: |
+            // noinspection JSUnresolvedVariable
+            
+            const imageName = `gcr.io/zeebe-io/zbchaos`
+            const versionRegex = /zbchaos v(?<version>\d+\.\d+\.\d+)/i
+            if (context.eventName === "release") {
+                const versionMatch = context.payload.release.name.match(versionRegex)
+                if (versionMatch == null) {
+                    core.warning(`Release was published but not detected as a zbchaos release. Tagging image only with sha ${context.sha}`)
+                    return `${imageName}:${context.sha}`
+                }
+                // For releases, tag with release version, sha and 'latest'
+                let version = versionMatch.groups["version"];
+                core.info(`Detected zbchaos release ${version}, tagging image ${imageName} with ${version}, 'latest' and sha ${context.sha}`)
+                return `${imageName}:${version},${imageName}:latest,${imageName}:${context.sha}`
+            } else {
+                // If not a release, tag only with sha
+                return `${imageName}:${context.sha}`
+            }
+          result-encoding: string
       - name: Setup BuildKit
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
@@ -24,6 +47,6 @@ jobs:
         with:
           context: go-chaos
           push: true
-          tags: gcr.io/zeebe-io/zbchaos:${{ env.VERSION }}
+          tags: ${{ steps.image-tags.outputs.result }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/go-chaos/deploy/deployment.yaml
+++ b/go-chaos/deploy/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zbchaos-worker
+  labels:
+    app: zbchaos-worker
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: zbchaos-worker
+  template:
+    metadata:
+      name: zbchaos-worker
+      labels:
+        app: zbchaos-worker
+    spec:
+      containers:
+        - image: gcr.io/zeebe-io/zbchaos:latest
+          name: zbchaos-worker
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 150m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /.kube
+              name: kubeconfig
+          envFrom:
+            - secretRef:
+                name: zeebe-backup-store-s3
+            - secretRef:
+                name: zbchaos-worker-client-config
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 420
+            items:
+              - key: kubeconfig
+                path: config
+            secretName: zbchaos-worker-kubeconfig


### PR DESCRIPTION
I've already created the secrets and deployed on both prod and dev namespaces.

This also fixes the workflow that publishes the zbchaos image on releases.

closes #199