### PR TITLE
feat: add command that can restore a cluster from a backup id

### DIFF
--- a/go-chaos/cmd/backup.go
+++ b/go-chaos/cmd/backup.go
@@ -15,12 +15,23 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	v12 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -38,6 +49,8 @@ func init() {
 	takeBackupCommand.Flags().StringVar(&backupId, "backupId", strconv.FormatInt(time.Now().UnixMilli(), 10), "optionally specify the backup id to use, uses the current timestamp by default")
 	backupCommand.AddCommand(waitForBackupCommand)
 	waitForBackupCommand.Flags().StringVar(&backupId, "backupId", strconv.FormatInt(time.Now().UnixMilli(), 10), "optionally specify the backup id to use, uses the current timestamp by default")
+	backupCommand.AddCommand(restoreBackupCommand)
+	restoreBackupCommand.Flags().StringVar(&backupId, "backupId", strconv.FormatInt(time.Now().UnixMilli(), 10), "optionally specify the backup id to use, uses the current timestamp by default")
 }
 
 var backupCommand = &cobra.Command{
@@ -56,6 +69,12 @@ var waitForBackupCommand = &cobra.Command{
 	Use:   "wait",
 	Short: "Wait for a backup to complete or fail",
 	RunE:  waitForBackup,
+}
+
+var restoreBackupCommand = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore from a given backup id",
+	RunE:  restoreFromBackup,
 }
 
 func takeBackup(cmd *cobra.Command, args []string) error {
@@ -104,6 +123,161 @@ func waitForBackup(cmd *cobra.Command, args []string) error {
 		time.Sleep(5 * time.Second)
 	}
 
+}
+
+func restoreFromBackup(cmd *cobra.Command, args []string) error {
+	k8Client, err := internal.CreateK8Client()
+	if err != nil {
+		panic(err)
+	}
+
+	namespace := k8Client.GetCurrentNamespace()
+	err = pauseReconciliation(cmd.Context(), k8Client, true)
+	if err != nil {
+		return err
+	}
+
+	sfsName, err := findStatefulSetName(cmd.Context(), k8Client, namespace)
+	sfs, err := k8Client.Clientset.AppsV1().StatefulSets(namespace).Get(cmd.Context(), sfsName, metav1.GetOptions{})
+
+	deleteContainer := v1.Container{
+		Name:            "delete-data",
+		Image:           "busybox",
+		ImagePullPolicy: v1.PullAlways,
+		Command:         []string{"sh", "-c", "rm -rf /usr/local/zeebe/data/* && ls -lah /usr/local/zeebe/data"},
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      "data",
+				ReadOnly:  false,
+				MountPath: "/usr/local/zeebe/data",
+			},
+		},
+	}
+	restoreContainer := v1.Container{
+		Name:            "restore-from-backup",
+		Image:           sfs.Spec.Template.Spec.Containers[0].Image,
+		ImagePullPolicy: v1.PullAlways,
+		Env:             restoreEnvFromSfs(sfs),
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      "data",
+				ReadOnly:  false,
+				MountPath: "/usr/local/zeebe/data",
+			},
+		},
+	}
+	initialScale := *sfs.Spec.Replicas
+
+	*sfs.Spec.Replicas = 0
+	sfs.Spec.Template.Spec.InitContainers = []v1.Container{deleteContainer, restoreContainer}
+
+	_, err = k8Client.Clientset.AppsV1().StatefulSets(namespace).Update(cmd.Context(), sfs, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Scale up after adding init containers.
+	err = scaleStatefulSet(cmd.Context(), k8Client, sfsName, initialScale)
+	if err != nil {
+		return err
+	}
+
+	err = pauseReconciliation(cmd.Context(), k8Client, false)
+	if err != nil {
+		return err
+	}
+
+	err = k8Client.AwaitReadiness()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findStatefulSetName(ctx context.Context, k8Client internal.K8Client, namespace string) (string, error) {
+	helmLabel := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/name": "zeebe"},
+	}
+	sfs, err := k8Client.Clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.Set(helmLabel.MatchLabels).String()})
+	if err != nil {
+		return "", err
+	}
+	if len(sfs.Items) == 1 {
+		return sfs.Items[0].Name, nil
+	}
+	if len(sfs.Items) == 0 {
+		saasSfs, err := k8Client.Clientset.AppsV1().StatefulSets(namespace).Get(ctx, "zeebe", metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		return saasSfs.Name, nil
+	}
+	return "", errors.New("could not uniquely identify the stateful set for Zeebe")
+}
+
+func pauseReconciliation(ctx context.Context, client internal.K8Client, pauseReconciliation bool) error {
+	namespace := client.GetCurrentNamespace()
+	clusterId := strings.TrimSuffix(namespace, "-zeebe")
+	config, err := client.ClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	zeebeCrd := schema.GroupVersionResource{Group: "cloud.camunda.io", Version: "v1alpha1", Resource: "ZeebeCluster"}
+	payload := fmt.Sprintf(`{"metadata": {"labels": {"cloud.camunda.io/pauseReconciliation": "%t"}}}`, pauseReconciliation)
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		_, err = dynamicClient.Resource(zeebeCrd).Patch(ctx, clusterId, types.MergePatchType, []byte(payload), metav1.PatchOptions{})
+		return err
+	})
+	if errors2.IsNotFound(err) {
+		// No zb resource found so probably not Saas. Ignore for now.
+		return nil
+	}
+	return err
+}
+
+func scaleStatefulSet(ctx context.Context, client internal.K8Client, statefulSetName string, replicas int32) error {
+	namespace := client.GetCurrentNamespace()
+	statefulSets := client.Clientset.AppsV1().StatefulSets(namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentScale, err := statefulSets.GetScale(ctx, statefulSetName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		currentScale.Spec.Replicas = replicas
+		_, err = statefulSets.UpdateScale(ctx, statefulSetName, currentScale, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func restoreEnvFromSfs(sfs *v12.StatefulSet) []v1.EnvVar {
+	zeebeEnv := sfs.Spec.Template.Spec.Containers[0].Env
+	restoreEnv := make([]v1.EnvVar, 0)
+	for _, env := range zeebeEnv {
+		// Filter out java tool options.
+		// If we don't, restore app will create a gc.log file in the data folder which prevents restoring because the data
+		// folder is not empty.
+		if env.Name != "JAVA_TOOL_OPTIONS" {
+			restoreEnv = append(restoreEnv, env)
+		}
+	}
+	restoreEnv = append(restoreEnv,
+		v1.EnvVar{
+			Name:  "ZEEBE_RESTORE",
+			Value: "true",
+		},
+		v1.EnvVar{
+			Name:  "ZEEBE_RESTORE_FROM_BACKUP_ID",
+			Value: backupId,
+		})
+	return restoreEnv
 }
 
 func getBackupStatus(port int, backupId string) (*BackupStatus, error) {

--- a/go-chaos/cmd/backup.go
+++ b/go-chaos/cmd/backup.go
@@ -90,7 +90,7 @@ func setupBackup(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_, err = copyBackupSecret(cmd, k8Client, namespace)
+	_, err = createBackupSecret(cmd, k8Client, namespace)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func setupGatewayForBackups(cmd *cobra.Command, err error, k8Client internal.K8C
 	return err
 }
 
-func copyBackupSecret(cmd *cobra.Command, k8Client internal.K8Client, namespace string) (*core.Secret, error) {
+func createBackupSecret(cmd *cobra.Command, k8Client internal.K8Client, namespace string) (*core.Secret, error) {
 	return k8Client.Clientset.CoreV1().Secrets(namespace).Create(
 		cmd.Context(),
 		&core.Secret{

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -53,7 +53,7 @@ type AuthenticationProvider struct {
 }
 
 type ZbChaosVariables struct {
-	ClusterId *string
+	ClusterId             *string
 	Provider              ChaosProvider
 	AuthenticationDetails AuthenticationProvider
 }

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
@@ -52,7 +53,7 @@ type AuthenticationProvider struct {
 }
 
 type ZbChaosVariables struct {
-	ClusterId             *string
+	ClusterId *string
 	Provider              ChaosProvider
 	AuthenticationDetails AuthenticationProvider
 }
@@ -108,6 +109,7 @@ func handleZbChaosJob(client worker.JobClient, job entities.Job) {
 }
 
 func runZbChaosCommand(args []string, ctx context.Context) error {
+	fmt.Printf("Running command with args: %v \n", args)
 	rootCmd.SetArgs(args)
 	_, err := rootCmd.ExecuteContextC(ctx)
 	if err != nil {

--- a/go-chaos/internal/cluster.go
+++ b/go-chaos/internal/cluster.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (

--- a/go-chaos/internal/cluster.go
+++ b/go-chaos/internal/cluster.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	v1 "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (c K8Client) GetZeebeStatefulSet() (*v1.StatefulSet, error) {
+	namespace := c.GetCurrentNamespace()
+	ctx := context.TODO()
+
+	helmLabel := meta.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/name": "zeebe"},
+	}
+
+	statefulSets := c.Clientset.AppsV1().StatefulSets(namespace)
+	sfs, err := statefulSets.List(ctx, meta.ListOptions{LabelSelector: labels.Set(helmLabel.MatchLabels).String()})
+	if err != nil {
+		return nil, err
+	}
+	if len(sfs.Items) == 1 {
+		return &sfs.Items[0], nil
+	}
+	if len(sfs.Items) == 0 {
+		// On SaaS the StatefulSet is just named "zeebe" without any identifying labels
+		return statefulSets.Get(ctx, "zeebe", meta.GetOptions{})
+	}
+	return nil, errors.New("could not uniquely identify the stateful set for Zeebe")
+}

--- a/go-chaos/internal/cluster.go
+++ b/go-chaos/internal/cluster.go
@@ -21,7 +21,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,12 +33,8 @@ func (c K8Client) GetZeebeStatefulSet() (*v1.StatefulSet, error) {
 	namespace := c.GetCurrentNamespace()
 	ctx := context.TODO()
 
-	helmLabel := meta.LabelSelector{
-		MatchLabels: map[string]string{"app.kubernetes.io/name": "zeebe"},
-	}
-
 	statefulSets := c.Clientset.AppsV1().StatefulSets(namespace)
-	sfs, err := statefulSets.List(ctx, meta.ListOptions{LabelSelector: labels.Set(helmLabel.MatchLabels).String()})
+	sfs, err := statefulSets.List(ctx, meta.ListOptions{LabelSelector: getSelfManagedZeebeStatefulSetLabels()})
 	if err != nil {
 		return nil, err
 	}

--- a/go-chaos/internal/helper_test.go
+++ b/go-chaos/internal/helper_test.go
@@ -55,12 +55,12 @@ func (c *testClientConfig) ConfigAccess() clientcmd.ConfigAccess {
 	panic("implement me")
 }
 
-func (k K8Client) CreatePodWithLabels(t *testing.T, selector *metav1.LabelSelector) {
-	k.CreatePodWithLabelsAndName(t, selector, "testPod")
+func (c K8Client) CreatePodWithLabels(t *testing.T, selector *metav1.LabelSelector) {
+	c.CreatePodWithLabelsAndName(t, selector, "testPod")
 }
 
-func (k K8Client) CreatePodWithLabelsAndName(t *testing.T, selector *metav1.LabelSelector, podName string) {
-	_, err := k.Clientset.CoreV1().Pods(k.GetCurrentNamespace()).Create(context.TODO(), &v1.Pod{
+func (c K8Client) CreatePodWithLabelsAndName(t *testing.T, selector *metav1.LabelSelector, podName string) {
+	_, err := c.Clientset.CoreV1().Pods(c.GetCurrentNamespace()).Create(context.TODO(), &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Labels: selector.MatchLabels, Name: podName},
 		Spec:       v1.PodSpec{},
 	}, metav1.CreateOptions{})
@@ -68,8 +68,8 @@ func (k K8Client) CreatePodWithLabelsAndName(t *testing.T, selector *metav1.Labe
 	require.NoError(t, err)
 }
 
-func (k K8Client) CreateDeploymentWithLabelsAndName(t *testing.T, selector *metav1.LabelSelector, podName string) {
-	_, err := k.Clientset.AppsV1().Deployments(k.GetCurrentNamespace()).Create(context.TODO(), &v12.Deployment{
+func (c K8Client) CreateDeploymentWithLabelsAndName(t *testing.T, selector *metav1.LabelSelector, podName string) {
+	_, err := c.Clientset.AppsV1().Deployments(c.GetCurrentNamespace()).Create(context.TODO(), &v12.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Labels: selector.MatchLabels, Name: podName},
 		Spec:       v12.DeploymentSpec{},
 		Status:     v12.DeploymentStatus{},

--- a/go-chaos/internal/k8helper.go
+++ b/go-chaos/internal/k8helper.go
@@ -36,7 +36,7 @@ type K8Client struct {
 }
 
 // Returns the current namespace, defined in the kubeconfig
-func (c *K8Client) GetCurrentNamespace() string {
+func (c K8Client) GetCurrentNamespace() string {
 	namespace, _, _ := c.ClientConfig.Namespace()
 	return namespace
 }

--- a/go-chaos/internal/k8helper.go
+++ b/go-chaos/internal/k8helper.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"fmt"
+	"k8s.io/client-go/dynamic"
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
@@ -29,8 +30,9 @@ import (
 )
 
 type K8Client struct {
-	ClientConfig clientcmd.ClientConfig
-	Clientset    kubernetes.Interface
+	ClientConfig  clientcmd.ClientConfig
+	DynamicClient dynamic.Interface
+	Clientset     kubernetes.Interface
 }
 
 // Returns the current namespace, defined in the kubeconfig
@@ -66,8 +68,11 @@ func createK8Client(settings KubernetesSettings) (K8Client, error) {
 	if Verbosity {
 		fmt.Printf("Connecting to %s\n", namespace)
 	}
-
-	return K8Client{Clientset: clientset, ClientConfig: clientConfig}, nil
+	dynamicClient, err := dynamic.NewForConfig(k8ClientConfig)
+	if err != nil {
+		return K8Client{}, err
+	}
+	return K8Client{Clientset: clientset, ClientConfig: clientConfig, DynamicClient: dynamicClient}, nil
 }
 
 type KubernetesSettings struct {

--- a/go-chaos/internal/labels.go
+++ b/go-chaos/internal/labels.go
@@ -19,6 +19,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+func getSelfManagedZeebeStatefulSetLabels() string {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/name": "zeebe"},
+	}
+	return labels.Set(labelSelector.MatchLabels).String()
+}
+
 func getSelfManagedBrokerLabels() string {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{"app.kubernetes.io/component": "zeebe-broker"},


### PR DESCRIPTION
This PR adds `backup setup` and `backup restore` commands and fix a couple of issues found while testing.