### PR TITLE
feat: commands use provided credentials to connect to the cluster under test

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,6 +42,9 @@ var (
 var Verbose bool
 var KubeConfigPath string
 var Namespace string
+var ClientId string
+var ClientSecret string
+var Audience string
 
 var rootCmd = &cobra.Command{
 	Use:   "zbchaos",
@@ -51,6 +55,13 @@ var rootCmd = &cobra.Command{
 		internal.Verbosity = Verbose
 		internal.Namespace = Namespace
 		internal.KubeConfigPath = KubeConfigPath
+		if ClientId != "" && ClientSecret != "" {
+			internal.ZeebeClientCredential, _ = zbc.NewOAuthCredentialsProvider(&zbc.OAuthProviderConfig{
+				ClientID:     ClientId,
+				ClientSecret: ClientSecret,
+				Audience:     Audience,
+			})
+		}
 	},
 }
 
@@ -58,6 +69,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&KubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "connect to the given namespace")
+	rootCmd.PersistentFlags().StringVarP(&ClientId, "clientId", "c", "", "connect using the given clientId")
+	rootCmd.PersistentFlags().StringVar(&ClientSecret, "clientSecret", "", "connect using the given client secret")
+	rootCmd.PersistentFlags().StringVar(&Audience, "audience", "", "connect using the given client secret")
 }
 
 func NewCmd() *cobra.Command {

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -43,9 +43,18 @@ type ChaosProvider struct {
 	Timeout   int64
 }
 
+type AuthenticationProvider struct {
+	Audience         string
+	AuthorizationUrl string
+	ClientId         string
+	ClientSecret     string
+	ContactPoint     string
+}
+
 type ZbChaosVariables struct {
-	ClusterId *string
-	Provider  ChaosProvider
+	ClusterId             *string
+	Provider              ChaosProvider
+	AuthenticationDetails AuthenticationProvider
 }
 
 func start_worker(cmd *cobra.Command, args []string) {
@@ -86,7 +95,8 @@ func handleZbChaosJob(client worker.JobClient, job entities.Job) {
 	commandCtx, cancelCommand := context.WithTimeout(ctx, timeout)
 	defer cancelCommand()
 
-	commandArgs := append([]string{"--namespace", *jobVariables.ClusterId + "-zeebe"}, jobVariables.Provider.Arguments...)
+	clusterAccessArgs := append([]string{""}, "--namespace", *jobVariables.ClusterId+"-zeebe", "--clientId", jobVariables.AuthenticationDetails.ClientId, "--clientSecret", jobVariables.AuthenticationDetails.ClientSecret, "--audience", jobVariables.AuthenticationDetails.Audience)
+	commandArgs := append(clusterAccessArgs, jobVariables.Provider.Arguments...)
 
 	err = runZbChaosCommand(commandArgs, commandCtx)
 	if err != nil {

--- a/go-chaos/internal/flags.go
+++ b/go-chaos/internal/flags.go
@@ -14,6 +14,8 @@
 
 package internal
 
+import "github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+
 // defines whether the functions should print verbose output
 var Verbosity bool = false
 
@@ -22,3 +24,5 @@ var KubeConfigPath string
 
 // sets the namespace to be used instead of the namespace from the current kube context
 var Namespace string
+
+var ZeebeClientCredential zbc.CredentialsProvider

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -30,6 +30,19 @@ import (
 
 func CreateZeebeClient(port int) (zbc.Client, error) {
 	endpoint := fmt.Sprintf("localhost:%d", port)
+	if ZeebeClientCredential != nil {
+		client, err := zbc.NewClient(&zbc.ClientConfig{
+			GatewayAddress:         endpoint,
+			DialOpts:               []grpc.DialOption{},
+			UsePlaintextConnection: false,
+			CredentialsProvider:    ZeebeClientCredential,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	}
+
 	client, err := zbc.NewClient(&zbc.ClientConfig{
 		GatewayAddress:         endpoint,
 		DialOpts:               []grpc.DialOption{},
@@ -38,7 +51,6 @@ func CreateZeebeClient(port int) (zbc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return client, nil
 }
 


### PR DESCRIPTION
Previously the client created inside a command to connect to a cluster was always using `UsePlaintextConnection=true`. This would not work with the clusters in ultrachaos. Testbench already passes the credentials via variables. This PR uses that credentials to access the cluster under test.

Manually tested this by running `zbchaos restart --namespace......` against a cluster running in ultrachaos. Also tested against a cluster in our benchmark cluster which requires insecure connection. Both works. Have not tested the zbchaos worker yet, because that would require deploying a new image with this changes. I will test it after merging this PR. 

closes #220 