### PR TITLE
Ignore dependabot PR's

### DIFF
--- a/.github/workflows/publishZbchaosImage.yml
+++ b/.github/workflows/publishZbchaosImage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish-image:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously dependabot PR's always fail, since the zbchaos docker build fails. The action has no access to the related secrets when dependabot creates an PR.