### PR TITLE
Deploy models via zbchaos

### DIFF
--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
+)
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+
+	deployCmd.AddCommand(deployProcessModelCmd)
+
+	deployProcessModelCmd.Flags().StringVar(&processModelPath, "processModelPath", "",
+		"Specify the path to a BPMN process model, which should be deployed.")
+	deployProcessModelCmd.Flags().IntVar(&multipleVersions, "multipleVersions", 10,
+		"Specify how many different versions of a default BPMN and DMN model should be deployed. Useful for testing deployment distribution.")
+
+	deployProcessModelCmd.MarkFlagsMutuallyExclusive("processModelPath", "multipleVersions")
+}
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Deploy certain resource",
+	Long:  `Deploy certain resource, like process model(s) or kubernetes manifest.`,
+}
+
+var deployProcessModelCmd = &cobra.Command{
+	Use:   "process",
+	Short: "Deploy a process model to Zeebe",
+	Long: `Deploy a process model to Zeebe. 
+Can be used to deploy a specific process model or multiple version of a default BPMN and DMN model.
+Defaults to the later, which is useful for experimenting with deployment distribution.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		k8Client, err := internal.CreateK8Client()
+		if err != nil {
+			panic(err)
+		}
+
+		port := 26500
+		closeFn := k8Client.MustGatewayPortForward(port, port)
+		defer closeFn()
+
+		zbClient, err := internal.CreateZeebeClient(port)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer zbClient.Close()
+
+		if len(processModelPath) == 0 {
+			// deploy multi version
+			err := internal.DeployDifferentVersions(zbClient, int32(multipleVersions))
+			if err != nil {
+				panic(err.Error())
+			}
+			fmt.Printf("Deployed different process models of different types and versions to zeebe!\n")
+		} else {
+			processDefinitionKey, err := internal.DeployModel(zbClient, processModelPath)
+			if err != nil {
+				panic(err.Error())
+			}
+
+			fmt.Printf("Deployed given process model %s, under key %d!\n", processModelPath, processDefinitionKey)
+		}
+	},
+}

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -16,8 +16,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"os"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
@@ -28,6 +29,7 @@ var (
 	role               string
 	nodeId             int
 	processModelPath   string
+	multipleVersions   int
 	variables          string
 	msgName            string
 	awaitResult        bool

--- a/go-chaos/internal/bpmn/multi-version/fancyDecision_v2.dmn
+++ b/go-chaos/internal/bpmn/multi-version/fancyDecision_v2.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_124x35b" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <decision id="fancyDecision" name="FancyDecision">
+    <decisionTable id="DecisionTable_1ldntm8">
+      <input id="InputClause_0m7yn14">
+        <inputExpression id="LiteralExpression_1r91tez" typeRef="string">
+          <text>"test"</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" name="dummy" typeRef="string" />
+      <rule id="DecisionRule_1ld2c9k">
+        <inputEntry id="UnaryTests_1u3isaf">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_17nti9y">
+          <text>"yolo"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="fancyDecision">
+        <dc:Bounds height="80" width="180" x="160" y="110" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Details
Add new sub command `deploy process` to deploy process models, either specified by the user
via `--processModelPath` or if not given it will deploy multiple versions of default models (BPMN and DMN).

The user is able to specify the count of versions which should be deployed for each.
This allows experimenting with deployment distribution.

Replacement of:

-  deploy-different-versions.sh
-  deploy-model.sh
-  deploy-specific-model.sh

closes https://github.com/zeebe-io/zeebe-chaos/issues/226
closes https://github.com/zeebe-io/zeebe-chaos/issues/160

### Example Usage:


```
$ ./zbchaos deploy process --verbose         
Connecting to zell-chaos
Successfully created port forwarding tunnel
Deploy 10 versions of different type of models.
Deployed [2/10] versions.
Deployed [4/10] versions.
Deployed [6/10] versions.
Deployed [8/10] versions.
Deployed [10/10] versions.
Deployed different process models of different types and versions to zeebe!
```


![bpmn](https://user-images.githubusercontent.com/2758593/202468706-1d7fb883-0226-4261-a24a-bdd0a6e91a77.png)
![dmn](https://user-images.githubusercontent.com/2758593/202468711-d98d8cb8-1f0d-4230-b05a-8995e0957f39.png)