### PR TITLE
Create process instance for specific version

### DIFF
--- a/go-chaos/internal/fake.go
+++ b/go-chaos/internal/fake.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+)
+
+/*
+Fake implementation of the Zeebe client.
+
+Can be used for unit tests to verify whether the right properties are set. Should be continously extended to
+increase test coverage.
+*/
+type FakeClient struct {
+	zbc.Client
+	commands.CreateInstanceCommandStep1
+	commands.CreateInstanceCommandStep2
+	commands.CreateInstanceCommandStep3
+	commands.DispatchCreateInstanceCommand
+
+	fakeResultCommand FakeResultCommand
+
+	processId   string
+	version     int32
+	vars        string
+	awaitResult bool
+}
+
+type FakeResultCommand struct {
+	commands.CreateInstanceWithResultCommandStep1
+	commands.DispatchCreateInstanceWithResultCommand
+}
+
+func (f *FakeClient) NewCreateInstanceCommand() commands.CreateInstanceCommandStep1 {
+	return f
+}
+
+func (f *FakeClient) BPMNProcessId(id string) commands.CreateInstanceCommandStep2 {
+	f.processId = id
+	return f
+}
+
+func (f *FakeClient) Version(v int32) commands.CreateInstanceCommandStep3 {
+	f.version = v
+	return f
+}
+
+func (f *FakeClient) VariablesFromString(json string) (commands.CreateInstanceCommandStep3, error) {
+	f.vars = json
+	return f, nil
+}
+
+func (f *FakeClient) WithResult() commands.CreateInstanceWithResultCommandStep1 {
+	f.awaitResult = true
+	return &f.fakeResultCommand
+}
+
+func (f *FakeClient) Send(ctx context.Context) (*pb.CreateProcessInstanceResponse, error) {
+	return &pb.CreateProcessInstanceResponse{ProcessInstanceKey: 0xCAFE}, nil
+}
+
+func (f *FakeResultCommand) Send(ctx context.Context) (*pb.CreateProcessInstanceWithResultResponse, error) {
+	return &pb.CreateProcessInstanceWithResultResponse{ProcessInstanceKey: 0xCAFE}, nil
+}


### PR DESCRIPTION
Allows creating a process instance for a specific version and BPMN process id via the verify steady-state command.
This is useful for the deployment distribution command.

Furthermore, I also created the first version of a Zeebe Fake client, in order to intercept values which are set on the client requests. This allows us to create more unit tests where we can verify whether the right properties and values are set.

Added some new tests for the process instance creation via version and BPMN process id.

closes https://github.com/zeebe-io/zeebe-chaos/issues/244

-----


**Example:**

Deploy model
```sh
$ ./zbchaos deploy process -v
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Deploy 10 versions of different type of models.
Deployed [2/10] versions.
Deployed [4/10] versions.
Deployed [6/10] versions.
Deployed [8/10] versions.
Deployed [10/10] versions.
Deployed different process models of different types and versions to zeebe!

```

Non-verbose: Start instance for a specific version
```
$ ./zbchaos verify steady-state --version 10 --bpmnProcessId multiVersion
The steady-state was successfully verified!
```

We can see in operate:

![execution](https://user-images.githubusercontent.com/2758593/203263224-a24a9f70-c956-4718-8fe7-50cde4c7610b.png)


Verbose: Start instance for a specific version

```sh
$ ./zbchaos verify steady-state --version 10 --bpmnProcessId multiVersion -v
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Create process instance with BPMN process ID multiVersion and version 10 [variables: '', awaitResult: false]
Created process instance with key 4503599627370497 on partition 2, required partition 1.
Created process instance with key 6755399441055745 on partition 3, required partition 1.
Created process instance with key 2251799813685299 on partition 1, required partition 1.
The steady-state was successfully verified!
```


![execution2](https://user-images.githubusercontent.com/2758593/203263565-cd7822cf-d0e0-4976-95f5-aecc41bd7cdf.png)
