### PR TITLE
Allow to deploy Zeebe workers with zbchaos

### DIFF
--- a/go-chaos/internal/deployment_test.go
+++ b/go-chaos/internal/deployment_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,4 +96,20 @@ func Test_ShouldReturnSaaSGatewayDeployment(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	assert.Equal(t, "gateway", deployment.Name)
+}
+
+func Test_ShouldDeployWorkerDeployment(t *testing.T) {
+	// given
+	k8Client := CreateFakeClient()
+
+	// when
+	err := k8Client.CreateWorkerDeployment()
+
+	// then
+	require.NoError(t, err)
+	deploymentList, err := k8Client.Clientset.AppsV1().Deployments(k8Client.GetCurrentNamespace()).List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(deploymentList.Items))
+	assert.Equal(t, "worker", deploymentList.Items[0].Name)
 }

--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+        - name: worker
+          image: gcr.io/zeebe-io/worker:zeebe
+          imagePullPolicy: Always
+          env:
+            - name: JAVA_OPTIONS
+              value: >-
+                -Dapp.brokerUrl=zeebe-service:26500
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=10
+                -Dapp.worker.pollingDelay=1ms
+                -Dapp.worker.completionDelay=50ms
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "debug"
+          resources:
+            limits:
+              cpu: 4
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: chaos-workers
+    app.kubernetes.io/name: zeebe-testbench
+  name: worker
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 9600
+      protocol: TCP
+      targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: worker
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -36,26 +36,3 @@ spec:
             requests:
               cpu: 1
               memory: 512Mi
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: zeebe
-    app.kubernetes.io/instance: chaos-workers
-    app.kubernetes.io/name: zeebe-testbench
-  name: worker
-spec:
-  clusterIP: None
-  ports:
-    - name: http
-      port: 9600
-      protocol: TCP
-      targetPort: 9600
-  publishNotReadyAddresses: true
-  selector:
-    app: worker
-  sessionAffinity: None
-  type: ClusterIP
-status:
-  loadBalancer: {}


### PR DESCRIPTION
Add new sub-command to deploy Zeebe workers into a Zeebe cluster, which can be used for several chaos experiments. This allows completing process instances etc.

closes https://github.com/zeebe-io/zeebe-chaos/issues/235

--------

**Example:**


Non-verbose: Deploy worker:

```sh
$ ./zbchaos deploy worker
Worker successfully deployed to the current namespace: zell-chaos
```

Verbose: Deploy worker

```sh
$ ./zbchaos deploy worker -v
Connecting to zell-chaos
Running experiment in self-managed environment.
Deploy worker deployment to the current namespace: zell-chaos
Worker successfully deployed to the current namespace: zell-chaos
```

```sh
$ k get deployments.apps 
NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
worker                     3/3     3            3           107s
```

Error when deployment already exists:


```
$ ./zbchaos deploy worker -v
Connecting to zell-chaos
Running experiment in self-managed environment.
Deploy worker deployment to the current namespace: zell-chaos
panic: deployments.apps "worker" already exists

```