### PR TITLE
Terminate/Restart workers

### DIFF
--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -68,7 +68,7 @@ var restartBrokerCmd = &cobra.Command{
 			panic(err)
 		}
 
-		fmt.Printf("Deleted %s", broker)
+		fmt.Printf("Restarted %s", broker)
 		fmt.Println()
 	},
 }

--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -24,17 +24,9 @@ import (
 
 func init() {
 	rootCmd.AddCommand(restartCmd)
-
-	restartCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER, INACTIVE]")
-	restartCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
-
-	if err := restartCmd.MarkFlagRequired("role"); err != nil {
-		panic(err)
-	}
-
-	if err := restartCmd.MarkFlagRequired("partitionId"); err != nil {
-		panic(err)
-	}
+	restartCmd.AddCommand(restartBrokerCmd)
+	restartBrokerCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER, INACTIVE]")
+	restartBrokerCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
 
 	restartCmd.AddCommand(restartGatewayCmd)
 	restartCmd.AddCommand(restartWorkerCmd)
@@ -43,6 +35,12 @@ func init() {
 
 var restartCmd = &cobra.Command{
 	Use:   "restart",
+	Short: "Restarts a Zeebe node",
+	Long:  `Restarts a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
+}
+
+var restartBrokerCmd = &cobra.Command{
+	Use:   "broker",
 	Short: "Restarts a Zeebe broker",
 	Long:  `Restarts a Zeebe broker with a certain role and given partition.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -70,7 +68,7 @@ var restartCmd = &cobra.Command{
 			panic(err)
 		}
 
-		fmt.Printf("\nDeleted %s", broker)
+		fmt.Printf("Deleted %s", broker)
 		fmt.Println()
 	},
 }

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -29,10 +29,11 @@ var (
 func init() {
 	rootCmd.AddCommand(terminateCmd)
 
-	terminateCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER]")
-	terminateCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
-	terminateCmd.Flags().IntVar(&nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
-	terminateCmd.MarkFlagsMutuallyExclusive("partitionId", "nodeId")
+	terminateCmd.AddCommand(terminateBrokerCmd)
+	terminateBrokerCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER]")
+	terminateBrokerCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
+	terminateBrokerCmd.Flags().IntVar(&nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
+	terminateBrokerCmd.MarkFlagsMutuallyExclusive("partitionId", "nodeId")
 
 	terminateCmd.AddCommand(terminateGatewayCmd)
 
@@ -42,6 +43,12 @@ func init() {
 
 var terminateCmd = &cobra.Command{
 	Use:   "terminate",
+	Short: "Terminates a Zeebe node",
+	Long:  `Terminates a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
+}
+
+var terminateBrokerCmd = &cobra.Command{
+	Use:   "broker",
 	Short: "Terminates a Zeebe broker",
 	Long:  `Terminates a Zeebe broker with a certain role and given partition.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/go-chaos/internal/labels.go
+++ b/go-chaos/internal/labels.go
@@ -74,3 +74,10 @@ func (c K8Client) getGatewayLabels() string {
 		return getSelfManagedGatewayLabels()
 	}
 }
+
+func (c K8Client) getWorkerLabels() string {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "worker"},
+	}
+	return labels.Set(labelSelector.MatchLabels).String()
+}

--- a/go-chaos/internal/pods.go
+++ b/go-chaos/internal/pods.go
@@ -94,6 +94,21 @@ func (c K8Client) GetGatewayPodNames() ([]string, error) {
 	return c.extractPodNames(list)
 }
 
+func (c K8Client) GetWorkerPods() (*v1.PodList, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.getWorkerLabels(),
+		// we check for running workers, since terminated workers can be lying around
+		FieldSelector: "status.phase=Running",
+	}
+
+	list, err := c.Clientset.CoreV1().Pods(c.GetCurrentNamespace()).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return list, err
+}
+
 func (c K8Client) TerminatePod(podName string) error {
 	gracePeriodSec := int64(0)
 	options := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSec}


### PR DESCRIPTION
With #247 we are able to deploy zeebe workers with zbchaos. With this PR we are able to restart and terminate workers, either one or all existing ones.

In this PR I also iterated over the terminate an restart commands and realized that gateway restart was missing. I added this.

Furthermore a new subcommand is added on terminate and restart for the broker, this makes it more understandable what is restarted, instead of using the root restart/terminate command for that.

I plan to do some more refactoring like extracting the duplicated code and reusing logic, but I will do this in a separate PR.


--------

**Example:** 

Terminate one:

```
$ ./zbchaos terminate worker -v
Connecting to zell-chaos
Running experiment in self-managed environment.
Terminated worker-99cd57f8b-hmhb5
```

Terminate all:

```
$ ./zbchaos terminate worker -v --all
Connecting to zell-chaos
Running experiment in self-managed environment.
Terminated worker-99cd57f8b-lfbck
Terminated worker-99cd57f8b-vjb9l
```

Restart one
```
$ ./zbchaos restart worker 
Restart worker-99cd57f8b-4ght7
```

Restart all
```
$ ./zbchaos restart worker --all
Restart worker-99cd57f8b-4ght7
Restart worker-99cd57f8b-7t2d9
Restart worker-99cd57f8b-kmrhv
```

New restart sub-commands:

```
$ ./zbchaos restart broker
Deleted zell-chaos-zeebe-2
$ ./zbchaos restart gateway
Restarted zell-chaos-zeebe-gateway-5f5c7cb8d6-9529r
$ ./zbchaos restart worker
Restart worker-99cd57f8b-cr6bs
```

New terminate sub-commands:
```
$ ./zbchaos terminate broker
Terminated zell-chaos-zeebe-0
$ ./zbchaos terminate gateway
Terminated zell-chaos-zeebe-gateway-5f5c7cb8d6-6jlxn
$ ./zbchaos terminate worker
Terminated worker-99cd57f8b-55tt2
```