### PR TITLE
Refactor the terminate/restart commands

### DIFF
--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -15,11 +15,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
 func init() {
@@ -66,28 +64,6 @@ var restartWorkerCmd = &cobra.Command{
 	Short: "Restart a Zeebe worker",
 	Long:  `Restart a Zeebe worker.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		ensureNoError(err)
-
-		workerPods, err := k8Client.GetWorkerPods()
-		ensureNoError(err)
-
-		if workerPods == nil || len(workerPods.Items) <= 0 {
-			panic(errors.New(fmt.Sprintf("Expected to find workers in namespace %s, but none found.", k8Client.GetCurrentNamespace())))
-		}
-
-		if all {
-			for _, worker := range workerPods.Items {
-				err = k8Client.RestartPod(worker.Name)
-				ensureNoError(err)
-				fmt.Printf("Restart %s\n", worker.Name)
-			}
-		} else {
-			workerPod := workerPods.Items[0]
-			err = k8Client.RestartPod(workerPod.Name)
-			ensureNoError(err)
-
-			fmt.Printf("Restart %s\n", workerPod.Name)
-		}
+		restartWorker(all, "Restarted", nil)
 	},
 }

--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -56,26 +56,7 @@ var restartGatewayCmd = &cobra.Command{
 	Short: "Restarts a Zeebe gateway",
 	Long:  `Restarts a Zeebe gateway.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		gatewayPodNames, err := k8Client.GetGatewayPodNames()
-		if err != nil {
-			panic(err)
-		}
-
-		if len(gatewayPodNames) <= 0 {
-			panic(errors.New(fmt.Sprintf("Expected to find Zeebe gateway in namespace %s, but none found.", k8Client.GetCurrentNamespace())))
-		}
-
-		gatewayPod := gatewayPodNames[0]
-		err = k8Client.RestartPod(gatewayPod)
-		if err != nil {
-			panic(err)
-		}
-
+		gatewayPod := restartGateway(nil)
 		fmt.Printf("Restarted %s\n", gatewayPod)
 	},
 }

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -58,6 +58,27 @@ var terminateBrokerCmd = &cobra.Command{
 	},
 }
 
+var terminateGatewayCmd = &cobra.Command{
+	Use:   "gateway",
+	Short: "Terminates a Zeebe gateway",
+	Long:  `Terminates a Zeebe gateway.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		gracePeriodSec := int64(0)
+		gatewayPod := restartGateway(&gracePeriodSec)
+		fmt.Printf("Terminated %s\n", gatewayPod)
+	},
+}
+
+var terminateWorkerCmd = &cobra.Command{
+	Use:   "worker",
+	Short: "Terminates a Zeebe worker",
+	Long:  `Terminates a Zeebe worker.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		gracePeriodSec := int64(0)
+		restartWorker(all, "Terminated", &gracePeriodSec)
+	},
+}
+
 // Restart a broker pod. Pod is identified either by nodeId or by partitionId and role.
 // GracePeriod (in second) can be negative, which would mean use default.
 // Returns the broker which has been restarted
@@ -80,17 +101,6 @@ func restartBroker(nodeId int, partitionId int, role string, gracePeriod *int64)
 	return brokerPod.Name
 }
 
-var terminateGatewayCmd = &cobra.Command{
-	Use:   "gateway",
-	Short: "Terminates a Zeebe gateway",
-	Long:  `Terminates a Zeebe gateway.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gracePeriodSec := int64(0)
-		gatewayPod := restartGateway(&gracePeriodSec)
-		fmt.Printf("Terminated %s\n", gatewayPod)
-	},
-}
-
 // Restart a gateway pod. The pod is the first from a list of existing pods.
 // GracePeriod (in second) can be negative, which would mean use default.
 // Returns the gateway which has been restarted
@@ -109,16 +119,6 @@ func restartGateway(gracePeriod *int64) string {
 	err = k8Client.RestartPodWithGracePeriod(gatewayPod, gracePeriod)
 	ensureNoError(err)
 	return gatewayPod
-}
-
-var terminateWorkerCmd = &cobra.Command{
-	Use:   "worker",
-	Short: "Terminates a Zeebe worker",
-	Long:  `Terminates a Zeebe worker.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gracePeriodSec := int64(0)
-		restartWorker(all, "Terminated", &gracePeriodSec)
-	},
 }
 
 // Restart a worker pod. The pod is the first from a list of existing pods, if all is not specified.

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -102,7 +102,7 @@ func restartBroker(nodeId int, partitionId int, role string, gracePeriod *int64)
 }
 
 // Restart a gateway pod. The pod is the first from a list of existing pods.
-// GracePeriod (in second) can be negative, which would mean use default.
+// GracePeriod (in second) can be nil, which would mean using K8 default.
 // Returns the gateway which has been restarted
 func restartGateway(gracePeriod *int64) string {
 	k8Client, err := internal.CreateK8Client()

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -122,7 +122,7 @@ func restartGateway(gracePeriod *int64) string {
 }
 
 // Restart a worker pod. The pod is the first from a list of existing pods, if all is not specified.
-// GracePeriod (in second) can be negative, which would mean use default.
+// GracePeriod (in second) can be nil, which would mean using K8 default.
 // The actionName specifies whether it was restarted or terminated to log the right thing.
 func restartWorker(all bool, actionName string, gracePeriod *int64) {
 	k8Client, err := internal.CreateK8Client()

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -80,7 +80,7 @@ var terminateWorkerCmd = &cobra.Command{
 }
 
 // Restart a broker pod. Pod is identified either by nodeId or by partitionId and role.
-// GracePeriod (in second) can be negative, which would mean use default.
+// GracePeriod (in second) can be nil, which would mean using K8 default.
 // Returns the broker which has been restarted
 func restartBroker(nodeId int, partitionId int, role string, gracePeriod *int64) string {
 	k8Client, err := internal.CreateK8Client()

--- a/go-chaos/internal/pods.go
+++ b/go-chaos/internal/pods.go
@@ -115,6 +115,11 @@ func (c K8Client) TerminatePod(podName string) error {
 	return c.Clientset.CoreV1().Pods(c.GetCurrentNamespace()).Delete(context.TODO(), podName, options)
 }
 
+func (c K8Client) RestartPodWithGracePeriod(podName string, gracePeriodSec *int64) error {
+	options := metav1.DeleteOptions{GracePeriodSeconds: gracePeriodSec}
+	return c.Clientset.CoreV1().Pods(c.GetCurrentNamespace()).Delete(context.TODO(), podName, options)
+}
+
 func (c K8Client) AwaitReadiness() error {
 	retries := 0
 	maxRetries := 300 // 5 * 60s


### PR DESCRIPTION
Extend the restart method to specify the gracePeriod allows to extract logic and reuse methods in restart and terminate commands.

Reduces several code duplications.