### PR TITLE
Ierate over steady-state cmd

### DIFF
--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"google.golang.org/grpc"
@@ -259,64 +258,42 @@ func readBPMNFileOrDefault(fileName string) ([]byte, string, error) {
 }
 
 type ProcessInstanceCreationOptions struct {
-	Version          int32
-	BpmnProcessId    string
-	ProcessModelPath string
-	Variables        string
-	AwaitResult      bool
+	Version       int32
+	BpmnProcessId string
+	Variables     string
+	AwaitResult   bool
 }
 
 func CreateProcessInstanceCreator(zbClient zbc.Client, options ProcessInstanceCreationOptions) (ProcessInstanceCreator, error) {
 	var processInstanceCreator ProcessInstanceCreator
-	if options.Version > 0 {
-		if Verbosity {
-			fmt.Printf("Create process instance with BPMN process ID %s and version %d [variables: '%s', awaitResult: %t]\n",
-				options.BpmnProcessId, options.Version, options.Variables, options.AwaitResult)
+	if Verbosity {
+		fmt.Printf("Create process instance with BPMN process ID %s and version %d [variables: '%s', awaitResult: %t]\n",
+			options.BpmnProcessId, options.Version, options.Variables, options.AwaitResult)
+	}
+
+	processInstanceCreator = func() (int64, error) {
+		commandStep3 := zbClient.NewCreateInstanceCommand().BPMNProcessId(options.BpmnProcessId).Version(options.Version)
+		if len(options.Variables) != 0 {
+			_, err := commandStep3.VariablesFromString(options.Variables)
+			if err != nil {
+				return 0, err
+			}
 		}
 
-		processInstanceCreator = func() (int64, error) {
-			commandStep3 := zbClient.NewCreateInstanceCommand().BPMNProcessId(options.BpmnProcessId).Version(int32(options.Version))
-			return createInstanceWithCommand(commandStep3, options)
+		if options.AwaitResult {
+			instanceWithResultResponse, err := commandStep3.WithResult().Send(context.TODO())
+			if err != nil {
+				return 0, err
+			}
+			return instanceWithResultResponse.ProcessInstanceKey, nil
 		}
-	} else {
-		processDefinitionKey, err := DeployModel(zbClient, options.ProcessModelPath)
+		instanceResponse, err := commandStep3.Send(context.TODO())
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
-
-		if Verbosity {
-			fmt.Printf("Create process instance with defition key %d [variables: '%s', awaitResult: %t]\n", processDefinitionKey, options.Variables, options.AwaitResult)
-		}
-
-		processInstanceCreator = func() (int64, error) {
-			commandStep3 := zbClient.NewCreateInstanceCommand().ProcessDefinitionKey(processDefinitionKey)
-
-			return createInstanceWithCommand(commandStep3, options)
-		}
+		return instanceResponse.ProcessInstanceKey, nil
 	}
 	return processInstanceCreator, nil
-}
-
-func createInstanceWithCommand(commandStep3 commands.CreateInstanceCommandStep3, options ProcessInstanceCreationOptions) (int64, error) {
-	if len(options.Variables) != 0 {
-		_, err := commandStep3.VariablesFromString(options.Variables)
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	if options.AwaitResult {
-		instanceWithResultResponse, err := commandStep3.WithResult().Send(context.TODO())
-		if err != nil {
-			return 0, err
-		}
-		return instanceWithResultResponse.ProcessInstanceKey, nil
-	}
-	instanceResponse, err := commandStep3.Send(context.TODO())
-	if err != nil {
-		return 0, err
-	}
-	return instanceResponse.ProcessInstanceKey, nil
 }
 
 type ProcessInstanceCreator func() (int64, error)


### PR DESCRIPTION
Rename command to `instance-creation`, because this is what it does or should do. Verifying whether instance creation works on a specific partition for a specific model.

Remove deployment from the command, and the processDefinitionKey usage. It is unlikely that we use this in our experiments it is easier to use the named process id and version (if not set we use the latest version). If we need it we can easily bring it back.

closes https://github.com/zeebe-io/zeebe-chaos/issues/249


----

**Example**

```sh
$ ./zbchaos verify instance-creation -v --bpmnProcessId multiVersion
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Create process instance with BPMN process ID multiVersion and version -1 [variables: '', awaitResult: false]
Created process instance with key 4503599627370507 on partition 2, required partition 1.
Created process instance with key 6755399441055755 on partition 3, required partition 1.
Created process instance with key 2251799813685309 on partition 1, required partition 1.
The steady-state was successfully verified!
```

