### PR TITLE
Deploy chaos process models

### DIFF
--- a/go-chaos/backend/clients.go
+++ b/go-chaos/backend/clients.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
+)
+
+func ConnectToZeebeCluster(k8Client internal.K8Client) (zbc.Client, func(), error) {
+	port := 26500
+	closeFn := k8Client.MustGatewayPortForward(port, port)
+
+	zbClient, err := internal.CreateZeebeClient(port)
+	if err != nil {
+		return nil, closeFn, err
+	}
+	return zbClient, func() {
+		zbClient.Close()
+		closeFn()
+	}, nil
+}

--- a/go-chaos/backend/clients.go
+++ b/go-chaos/backend/clients.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package backend
 
 import (

--- a/go-chaos/backend/connection.go
+++ b/go-chaos/backend/connection.go
@@ -132,20 +132,6 @@ func DisconnectBroker(disconnectBrokerCfg DisconnectBrokerCfg) error {
 	return disconnectPods(k8Client, broker1Pod, broker2Pod, disconnectBrokerCfg.OneDirection)
 }
 
-func ConnectToZeebeCluster(k8Client internal.K8Client) (zbc.Client, func(), error) {
-	port := 26500
-	closeFn := k8Client.MustGatewayPortForward(port, port)
-
-	zbClient, err := internal.CreateZeebeClient(port)
-	if err != nil {
-		return nil, closeFn, err
-	}
-	return zbClient, func() {
-		zbClient.Close()
-		closeFn()
-	}, nil
-}
-
 type DisconnectGatewayCfg struct {
 	DisconnectToAll bool
 	OneDirection    bool

--- a/go-chaos/internal/bpmn/chaos/actionRunner.bpmn
+++ b/go-chaos/internal/bpmn/chaos/actionRunner.bpmn
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_09krf3y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
+  <bpmn:process id="actionRunner" isExecutable="true">
+    <bpmn:startEvent id="Event_1hncl4g" name="Run provided action">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=true" target="successfulRun" />
+          <zeebe:output source="=if (is defined(action.provider.timeout)) then &#34;PT&#34; + string(action.provider.timeout) + &#34;S&#34; else &#34;PT1H&#34;" target="timeout" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_13awudk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_1xzr6io" name="Run action">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="=action.provider.path" />
+        <zeebe:ioMapping>
+          <zeebe:input source="= action.provider" target="provider" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13awudk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ac5qfr</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1d8stud" name="Should pause after action?" default="Flow_1m0oez8">
+      <bpmn:incoming>Flow_0ac5qfr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1875nuz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1m0oez8</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0gybtdt">
+      <bpmn:incoming>Flow_1m0oez8</bpmn:incoming>
+      <bpmn:incoming>Flow_1okm6sv</bpmn:incoming>
+      <bpmn:outgoing>Flow_06wxvcu</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="Event_13pyqn2" name="Action succeeded">
+      <bpmn:incoming>Flow_06wxvcu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateCatchEvent id="Event_0zo9lot">
+      <bpmn:incoming>Flow_1875nuz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1okm6sv</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1t6j705">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=duration("PT" + string(action.pauses.after) + "S")</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_13awudk" sourceRef="Event_1hncl4g" targetRef="Activity_1xzr6io" />
+    <bpmn:sequenceFlow id="Flow_0ac5qfr" sourceRef="Activity_1xzr6io" targetRef="Gateway_1d8stud" />
+    <bpmn:sequenceFlow id="Flow_1875nuz" name="Yes" sourceRef="Gateway_1d8stud" targetRef="Event_0zo9lot">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=is defined(action.pauses)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1m0oez8" name="No" sourceRef="Gateway_1d8stud" targetRef="Gateway_0gybtdt" />
+    <bpmn:sequenceFlow id="Flow_1okm6sv" sourceRef="Event_0zo9lot" targetRef="Gateway_0gybtdt" />
+    <bpmn:sequenceFlow id="Flow_06wxvcu" sourceRef="Gateway_0gybtdt" targetRef="Event_13pyqn2" />
+    <bpmn:boundaryEvent id="Event_0owkcly" name="Timeout" attachedToRef="Activity_1xzr6io">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Action with name: &#39;&#34; + action.name + &#34;&#39; timed out after &#34; + timeout + &#34;.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="= false" target="successfulRun" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0yhcmxv</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1eo7nl1">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=duration(timeout)</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0yhcmxv" sourceRef="Event_0owkcly" targetRef="Event_1quq7fu" />
+    <bpmn:endEvent id="Event_1quq7fu" name="Action failed">
+      <bpmn:incoming>Flow_0yhcmxv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_1pm343k">
+      <bpmn:text>Per default 1 hour, can be overwritten by executed action</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0svhcej" sourceRef="Event_0owkcly" targetRef="TextAnnotation_1pm343k" />
+  </bpmn:process>
+  <bpmn:error id="Error_0f989kq" name="action failed" errorCode="failedAction" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="actionRunner">
+      <bpmndi:BPMNEdge id="Flow_0yhcmxv_di" bpmnElement="Flow_0yhcmxv">
+        <di:waypoint x="320" y="208" />
+        <di:waypoint x="320" y="310" />
+        <di:waypoint x="722" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06wxvcu_di" bpmnElement="Flow_06wxvcu">
+        <di:waypoint x="665" y="150" />
+        <di:waypoint x="722" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1okm6sv_di" bpmnElement="Flow_1okm6sv">
+        <di:waypoint x="558" y="260" />
+        <di:waypoint x="640" y="260" />
+        <di:waypoint x="640" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m0oez8_di" bpmnElement="Flow_1m0oez8">
+        <di:waypoint x="485" y="150" />
+        <di:waypoint x="615" y="150" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="543" y="132" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1875nuz_di" bpmnElement="Flow_1875nuz">
+        <di:waypoint x="460" y="175" />
+        <di:waypoint x="460" y="260" />
+        <di:waypoint x="522" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="466" y="215" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ac5qfr_di" bpmnElement="Flow_0ac5qfr">
+        <di:waypoint x="390" y="150" />
+        <di:waypoint x="435" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13awudk_di" bpmnElement="Flow_13awudk">
+        <di:waypoint x="248" y="150" />
+        <di:waypoint x="290" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1hncl4g_di" bpmnElement="Event_1hncl4g">
+        <dc:Bounds x="212" y="132" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="198" y="175" width="66" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xzr6io_di" bpmnElement="Activity_1xzr6io">
+        <dc:Bounds x="290" y="110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1d8stud_di" bpmnElement="Gateway_1d8stud" isMarkerVisible="true">
+        <dc:Bounds x="435" y="125" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="426" y="86" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gybtdt_di" bpmnElement="Gateway_0gybtdt" isMarkerVisible="true">
+        <dc:Bounds x="615" y="125" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13pyqn2_di" bpmnElement="Event_13pyqn2">
+        <dc:Bounds x="722" y="132" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="697" y="175" width="87" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zo9lot_di" bpmnElement="Event_0zo9lot">
+        <dc:Bounds x="522" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0s989l1_di" bpmnElement="Event_1quq7fu">
+        <dc:Bounds x="722" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="710" y="335" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1pm343k_di" bpmnElement="TextAnnotation_1pm343k">
+        <dc:Bounds x="180" y="270" width="100" height="68" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bnzi0o_di" bpmnElement="Event_0owkcly">
+        <dc:Bounds x="302" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="340" y="215" width="40" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0svhcej_di" bpmnElement="Association_0svhcej">
+        <di:waypoint x="308" y="203" />
+        <di:waypoint x="244" y="270" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/go-chaos/internal/bpmn/chaos/chaosExperiment.bpmn
+++ b/go-chaos/internal/bpmn/chaos/chaosExperiment.bpmn
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_06vr52u" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
+  <bpmn:process id="chaosExperiment" isExecutable="true">
+    <bpmn:subProcess id="Activity_11tzpu9" name="Chaos Experiment">
+      <bpmn:incoming>Flow_0ll1uwh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1weinm8</bpmn:outgoing>
+      <bpmn:endEvent id="Event_0ulf3ce">
+        <bpmn:incoming>Flow_1itk0ag</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="Event_1u9f9sk">
+        <bpmn:outgoing>Flow_0sqgo4r</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:subProcess id="Activity_1cxs1dd" name="Verify Steady State">
+        <bpmn:incoming>Flow_0sqgo4r</bpmn:incoming>
+        <bpmn:outgoing>Flow_0uiwbuz</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=steadyState.probes" inputElement="action" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:startEvent id="Event_1acs4yl">
+          <bpmn:outgoing>Flow_1or504g</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:callActivity id="Activity_08p87mg" name="Run verification">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="actionRunner" propagateAllChildVariables="true" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1or504g</bpmn:incoming>
+          <bpmn:outgoing>Flow_104lujp</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:sequenceFlow id="Flow_1or504g" sourceRef="Event_1acs4yl" targetRef="Activity_08p87mg" />
+        <bpmn:exclusiveGateway id="Gateway_03n7r1p" name="Successful run?" default="Flow_0erwgmy">
+          <bpmn:incoming>Flow_104lujp</bpmn:incoming>
+          <bpmn:outgoing>Flow_0erwgmy</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0vh336v</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_104lujp" sourceRef="Activity_08p87mg" targetRef="Gateway_03n7r1p" />
+        <bpmn:endEvent id="Event_1rgucvf">
+          <bpmn:incoming>Flow_0erwgmy</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_0erwgmy" name="Yes" sourceRef="Gateway_03n7r1p" targetRef="Event_1rgucvf" />
+        <bpmn:sequenceFlow id="Flow_0vh336v" name="No" sourceRef="Gateway_03n7r1p" targetRef="Event_0sw0eal">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=successfulRun = false</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:endEvent id="Event_0sw0eal">
+          <bpmn:incoming>Flow_0vh336v</bpmn:incoming>
+          <bpmn:errorEventDefinition id="ErrorEventDefinition_1jithbt" errorRef="Error_0wc7vts" />
+        </bpmn:endEvent>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_0sqgo4r" sourceRef="Event_1u9f9sk" targetRef="Activity_1cxs1dd" />
+      <bpmn:subProcess id="Activity_0nqerfm" name="Introduce Chaos">
+        <bpmn:incoming>Flow_0uiwbuz</bpmn:incoming>
+        <bpmn:outgoing>Flow_1urawfk</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=method" inputElement="action" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:startEvent id="Event_00iakpz">
+          <bpmn:outgoing>Flow_10u4oy7</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:callActivity id="Activity_1jg7jgx" name="Introduce Chaos">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="actionRunner" propagateAllChildVariables="true" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_10u4oy7</bpmn:incoming>
+          <bpmn:outgoing>Flow_0fgc04f</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:exclusiveGateway id="Gateway_0i6jab9" name="Successful run?" default="Flow_1d9u51w">
+          <bpmn:incoming>Flow_0fgc04f</bpmn:incoming>
+          <bpmn:outgoing>Flow_1d9u51w</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0yi4wz0</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:endEvent id="Event_1r630xy">
+          <bpmn:incoming>Flow_1d9u51w</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:endEvent id="Event_1qfgzc8">
+          <bpmn:incoming>Flow_0yi4wz0</bpmn:incoming>
+          <bpmn:errorEventDefinition id="ErrorEventDefinition_048xj82" errorRef="Error_0wc7vts" />
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_10u4oy7" sourceRef="Event_00iakpz" targetRef="Activity_1jg7jgx" />
+        <bpmn:sequenceFlow id="Flow_0fgc04f" sourceRef="Activity_1jg7jgx" targetRef="Gateway_0i6jab9" />
+        <bpmn:sequenceFlow id="Flow_1d9u51w" name="Yes" sourceRef="Gateway_0i6jab9" targetRef="Event_1r630xy" />
+        <bpmn:sequenceFlow id="Flow_0yi4wz0" name="No" sourceRef="Gateway_0i6jab9" targetRef="Event_1qfgzc8">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=successfulRun = false</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_0uiwbuz" sourceRef="Activity_1cxs1dd" targetRef="Activity_0nqerfm" />
+      <bpmn:subProcess id="Activity_1elridj" name="Verify Steady State">
+        <bpmn:incoming>Flow_1urawfk</bpmn:incoming>
+        <bpmn:outgoing>Flow_1itk0ag</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=steadyState.probes" inputElement="action" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:startEvent id="Event_0j24lps">
+          <bpmn:outgoing>Flow_0m1gisv</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:callActivity id="Activity_11qmcik" name="Run verification">
+          <bpmn:extensionElements>
+            <zeebe:calledElement processId="actionRunner" propagateAllChildVariables="true" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0m1gisv</bpmn:incoming>
+          <bpmn:outgoing>Flow_1br1dnv</bpmn:outgoing>
+        </bpmn:callActivity>
+        <bpmn:exclusiveGateway id="Gateway_0jwe1c7" name="Successful run?" default="Flow_05mvpkj">
+          <bpmn:incoming>Flow_1br1dnv</bpmn:incoming>
+          <bpmn:outgoing>Flow_05mvpkj</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0l3cz4w</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:endEvent id="Event_1ypntjj">
+          <bpmn:incoming>Flow_05mvpkj</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:endEvent id="Event_165b83s">
+          <bpmn:incoming>Flow_0l3cz4w</bpmn:incoming>
+          <bpmn:errorEventDefinition id="ErrorEventDefinition_161876x" errorRef="Error_0wc7vts" />
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_0m1gisv" sourceRef="Event_0j24lps" targetRef="Activity_11qmcik" />
+        <bpmn:sequenceFlow id="Flow_1br1dnv" sourceRef="Activity_11qmcik" targetRef="Gateway_0jwe1c7" />
+        <bpmn:sequenceFlow id="Flow_05mvpkj" name="Yes" sourceRef="Gateway_0jwe1c7" targetRef="Event_1ypntjj" />
+        <bpmn:sequenceFlow id="Flow_0l3cz4w" name="No" sourceRef="Gateway_0jwe1c7" targetRef="Event_165b83s">
+          <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=successfulRun = false</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_1urawfk" sourceRef="Activity_0nqerfm" targetRef="Activity_1elridj" />
+      <bpmn:sequenceFlow id="Flow_1itk0ag" sourceRef="Activity_1elridj" targetRef="Event_0ulf3ce" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_06uq3eg" name="Chaos Experiment failed" attachedToRef="Activity_11tzpu9">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Chaos experiment &#39;&#34; + experiment.title + &#34;&#39; failed.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="= false" target="successfulExperiment" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_104ij14</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1jbnwcd" errorRef="Error_0wc7vts" />
+    </bpmn:boundaryEvent>
+    <bpmn:exclusiveGateway id="Gateway_1ty24uf">
+      <bpmn:incoming>Flow_104ij14</bpmn:incoming>
+      <bpmn:incoming>Flow_1yombys</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h0aa5x</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:boundaryEvent id="Event_036qm76" name="Timeout after 3 hours" attachedToRef="Activity_11tzpu9">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Chaos experiment &#34; + experiment.title + &#34; failed.&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="= false" target="successfulExperiment" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1yombys</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0e3kasa">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT3H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_104ij14" sourceRef="Event_06uq3eg" targetRef="Gateway_1ty24uf" />
+    <bpmn:sequenceFlow id="Flow_1yombys" sourceRef="Event_036qm76" targetRef="Gateway_1ty24uf" />
+    <bpmn:endEvent id="Event_0cqap4f" name="Chaos Experiment succeeded">
+      <bpmn:incoming>Flow_1weinm8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_1" name="Run Chaos Experiment">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= true" target="successfulExperiment" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0ll1uwh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0ll1uwh" sourceRef="StartEvent_1" targetRef="Activity_11tzpu9" />
+    <bpmn:sequenceFlow id="Flow_1weinm8" sourceRef="Activity_11tzpu9" targetRef="Event_0cqap4f" />
+    <bpmn:sequenceFlow id="Flow_0h0aa5x" sourceRef="Gateway_1ty24uf" targetRef="Event_0i9wjj1" />
+    <bpmn:endEvent id="Event_0i9wjj1" name="Chaos Experiment failed">
+      <bpmn:incoming>Flow_0h0aa5x</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_0gj5btv" name="experiment-timeout" errorCode="experiment-timeout" />
+  <bpmn:error id="Error_0wc7vts" name="action failed" errorCode="failedAction" />
+  <bpmn:error id="Error_1gwy61z" name="experimentFailed" errorCode="experimentFailed" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="chaosExperiment">
+      <bpmndi:BPMNEdge id="Flow_0h0aa5x_di" bpmnElement="Flow_0h0aa5x">
+        <di:waypoint x="1405" y="570" />
+        <di:waypoint x="1862" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1weinm8_di" bpmnElement="Flow_1weinm8">
+        <di:waypoint x="1830" y="280" />
+        <di:waypoint x="1862" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ll1uwh_di" bpmnElement="Flow_0ll1uwh">
+        <di:waypoint x="198" y="270" />
+        <di:waypoint x="240" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yombys_di" bpmnElement="Flow_1yombys">
+        <di:waypoint x="1380" y="478" />
+        <di:waypoint x="1380" y="545" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_104ij14_di" bpmnElement="Flow_104ij14">
+        <di:waypoint x="1030" y="478" />
+        <di:waypoint x="1030" y="570" />
+        <di:waypoint x="1355" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1cqlnii_di" bpmnElement="Activity_11tzpu9" isExpanded="true">
+        <dc:Bounds x="240" y="120" width="1590" height="340" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1itk0ag_di" bpmnElement="Flow_1itk0ag">
+        <di:waypoint x="1750" y="280" />
+        <di:waypoint x="1772" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1urawfk_di" bpmnElement="Flow_1urawfk">
+        <di:waypoint x="1270" y="280" />
+        <di:waypoint x="1300" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uiwbuz_di" bpmnElement="Flow_0uiwbuz">
+        <di:waypoint x="780" y="280" />
+        <di:waypoint x="820" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sqgo4r_di" bpmnElement="Flow_0sqgo4r">
+        <di:waypoint x="298" y="280" />
+        <di:waypoint x="330" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ulf3ce_di" bpmnElement="Event_0ulf3ce">
+        <dc:Bounds x="1772" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u9f9sk_di" bpmnElement="Event_1u9f9sk">
+        <dc:Bounds x="262" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cxs1dd_di" bpmnElement="Activity_1cxs1dd" isExpanded="true">
+        <dc:Bounds x="330" y="180" width="450" height="230" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0vh336v_di" bpmnElement="Flow_0vh336v">
+        <di:waypoint x="620" y="305" />
+        <di:waypoint x="620" y="360" />
+        <di:waypoint x="712" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="628" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0erwgmy_di" bpmnElement="Flow_0erwgmy">
+        <di:waypoint x="645" y="280" />
+        <di:waypoint x="712" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="660" y="263" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_104lujp_di" bpmnElement="Flow_104lujp">
+        <di:waypoint x="540" y="280" />
+        <di:waypoint x="595" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1or504g_di" bpmnElement="Flow_1or504g">
+        <di:waypoint x="386" y="280" />
+        <di:waypoint x="440" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1acs4yl_di" bpmnElement="Event_1acs4yl">
+        <dc:Bounds x="350" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08p87mg_di" bpmnElement="Activity_08p87mg">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03n7r1p_di" bpmnElement="Gateway_03n7r1p" isMarkerVisible="true">
+        <dc:Bounds x="595" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="581" y="233" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rgucvf_di" bpmnElement="Event_1rgucvf">
+        <dc:Bounds x="712" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iklunk_di" bpmnElement="Event_0sw0eal">
+        <dc:Bounds x="712" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nqerfm_di" bpmnElement="Activity_0nqerfm" isExpanded="true">
+        <dc:Bounds x="820" y="180" width="450" height="230" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yi4wz0_di" bpmnElement="Flow_0yi4wz0">
+        <di:waypoint x="1110" y="305" />
+        <di:waypoint x="1110" y="360" />
+        <di:waypoint x="1202" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1118" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d9u51w_di" bpmnElement="Flow_1d9u51w">
+        <di:waypoint x="1135" y="280" />
+        <di:waypoint x="1202" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1150" y="263" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fgc04f_di" bpmnElement="Flow_0fgc04f">
+        <di:waypoint x="1030" y="280" />
+        <di:waypoint x="1085" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10u4oy7_di" bpmnElement="Flow_10u4oy7">
+        <di:waypoint x="876" y="280" />
+        <di:waypoint x="930" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_00iakpz_di" bpmnElement="Event_00iakpz">
+        <dc:Bounds x="840" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jg7jgx_di" bpmnElement="Activity_1jg7jgx">
+        <dc:Bounds x="930" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i6jab9_di" bpmnElement="Gateway_0i6jab9" isMarkerVisible="true">
+        <dc:Bounds x="1085" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1071" y="233" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1r630xy_di" bpmnElement="Event_1r630xy">
+        <dc:Bounds x="1202" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1qfgzc8_di" bpmnElement="Event_1qfgzc8">
+        <dc:Bounds x="1202" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1elridj_di" bpmnElement="Activity_1elridj" isExpanded="true">
+        <dc:Bounds x="1300" y="180" width="450" height="230" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0l3cz4w_di" bpmnElement="Flow_0l3cz4w">
+        <di:waypoint x="1590" y="305" />
+        <di:waypoint x="1590" y="360" />
+        <di:waypoint x="1682" y="360" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1598" y="330" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05mvpkj_di" bpmnElement="Flow_05mvpkj">
+        <di:waypoint x="1615" y="280" />
+        <di:waypoint x="1682" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1630" y="263" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1br1dnv_di" bpmnElement="Flow_1br1dnv">
+        <di:waypoint x="1510" y="280" />
+        <di:waypoint x="1565" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1gisv_di" bpmnElement="Flow_0m1gisv">
+        <di:waypoint x="1356" y="280" />
+        <di:waypoint x="1410" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0j24lps_di" bpmnElement="Event_0j24lps">
+        <dc:Bounds x="1320" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11qmcik_di" bpmnElement="Activity_11qmcik">
+        <dc:Bounds x="1410" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0jwe1c7_di" bpmnElement="Gateway_0jwe1c7" isMarkerVisible="true">
+        <dc:Bounds x="1565" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1551" y="233" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ypntjj_di" bpmnElement="Event_1ypntjj">
+        <dc:Bounds x="1682" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_165b83s_di" bpmnElement="Event_165b83s">
+        <dc:Bounds x="1682" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ty24uf_di" bpmnElement="Gateway_1ty24uf" isMarkerVisible="true">
+        <dc:Bounds x="1355" y="545" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cqap4f_di" bpmnElement="Event_0cqap4f">
+        <dc:Bounds x="1862" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1852" y="305" width="56" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="162" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="152" y="295" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03kptlx_di" bpmnElement="Event_0i9wjj1">
+        <dc:Bounds x="1862" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1838" y="595" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07yabv0_di" bpmnElement="Event_036qm76">
+        <dc:Bounds x="1362" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1403" y="466" width="74" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06uq3eg_di" bpmnElement="Event_06uq3eg">
+        <dc:Bounds x="1012" y="442" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1037" y="476" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/go-chaos/internal/bpmn/chaos/chaosToolkit.bpmn
+++ b/go-chaos/internal/bpmn/chaos/chaosToolkit.bpmn
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_083lt9z" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
+  <bpmn:process id="chaosToolkit" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Run Chaos experiments">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=((now() - date and time(&#34;1970-01-01T00:00Z&#34;)) / duration(&#34;PT1S&#34;)) * 1000" target="testReport.startTime" />
+          <zeebe:output source="=[]" target="testReport.failureMessages" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0kbumzp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0kbumzp" sourceRef="StartEvent_1" targetRef="Activity_0a7hels" />
+    <bpmn:serviceTask id="Activity_0a7hels" name="Read all experiments for cluster plan">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="readExperiments" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0kbumzp</bpmn:incoming>
+      <bpmn:outgoing>Flow_19dyj0t</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_19dyj0t" sourceRef="Activity_0a7hels" targetRef="Activity_1neh8m1" />
+    <bpmn:subProcess id="Activity_1neh8m1" name="Chaos Experiments">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=((now() - date and time(&#34;1970-01-01T00:00Z&#34;)) / duration(&#34;PT1S&#34;)) * 1000" target="testReport.endTime" />
+          <zeebe:output source="=&#34;PASSED&#34;" target="testReport.testResult" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19dyj0t</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ots415</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=experiments" inputElement="experiment" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:callActivity id="Activity_1a7lifm" name="Run Chaos experiment for cluster plan">
+        <bpmn:extensionElements>
+          <zeebe:calledElement processId="chaosExperiment" propagateAllChildVariables="true" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=experiment.title" target="title" />
+            <zeebe:input source="=experiment.description" target="description" />
+            <zeebe:input source="=experiment.`steady-state-hypothesis`" target="steadyState" />
+            <zeebe:input source="=experiment.method" target="method" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1jze8zi</bpmn:incoming>
+        <bpmn:outgoing>Flow_19ibrle</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:endEvent id="Event_1riaxno" name="Chaos experiment succeeded">
+        <bpmn:incoming>Flow_0bp4b07</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_19ibrle" sourceRef="Activity_1a7lifm" targetRef="Gateway_0k7901b" />
+      <bpmn:startEvent id="Event_0c2kswe" name="Run Chaos">
+        <bpmn:outgoing>Flow_1jze8zi</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1jze8zi" sourceRef="Event_0c2kswe" targetRef="Activity_1a7lifm" />
+      <bpmn:exclusiveGateway id="Gateway_0k7901b" name="Successful experiment?" default="Flow_0bp4b07">
+        <bpmn:incoming>Flow_19ibrle</bpmn:incoming>
+        <bpmn:outgoing>Flow_0bp4b07</bpmn:outgoing>
+        <bpmn:outgoing>Flow_0lzo5zw</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:sequenceFlow id="Flow_0bp4b07" name="Yes" sourceRef="Gateway_0k7901b" targetRef="Event_1riaxno" />
+      <bpmn:sequenceFlow id="Flow_0lzo5zw" name="No" sourceRef="Gateway_0k7901b" targetRef="Event_0206bt7">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=successfulExperiment = false</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="Event_0206bt7" name="Chaos experiment failed">
+        <bpmn:incoming>Flow_0lzo5zw</bpmn:incoming>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_12jxl5o" errorRef="Error_0wkiw9h" />
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_15ycupq" name="Chaos Experiment failed" attachedToRef="Activity_1neh8m1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=append(testReport.failureMessages, (&#34; Experiment failed for cluster plan: &#39;&#34; + clusterPlan + &#34;&#39; against cluster &#39;&#34; + clusterName + &#34;&#39; (&#34; + clusterId + &#34;).&#34;))" target="testReport.failureMessages" />
+          <zeebe:output source="= 1" target="testReport.failureCount" />
+          <zeebe:output source="=&#34;FAILED&#34;" target="testReport.testResult" />
+          <zeebe:output source="=((now() - date and time(&#34;1970-01-01T00:00Z&#34;)) / duration(&#34;PT1S&#34;)) * 1000" target="testReport.endTime" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1c8oxlz</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0e0k38x" errorRef="Error_0wkiw9h" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_0fhnwbl" name="Failed to run chaos experiments">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="= source" target="target" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c8oxlz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_152ucof" name="Chaos experiments succeeded">
+      <bpmn:incoming>Flow_1ots415</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ots415" sourceRef="Activity_1neh8m1" targetRef="Event_152ucof" />
+    <bpmn:sequenceFlow id="Flow_1c8oxlz" sourceRef="Event_15ycupq" targetRef="Event_0fhnwbl" />
+  </bpmn:process>
+  <bpmn:error id="Error_0wkiw9h" name="experimentFailed" errorCode="experimentFailed" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="chaosToolkit">
+      <bpmndi:BPMNEdge id="Flow_1c8oxlz_di" bpmnElement="Flow_1c8oxlz">
+        <di:waypoint x="890" y="418" />
+        <di:waypoint x="890" y="470" />
+        <di:waypoint x="1022" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ots415_di" bpmnElement="Flow_1ots415">
+        <di:waypoint x="960" y="225" />
+        <di:waypoint x="1022" y="225" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19dyj0t_di" bpmnElement="Flow_19dyj0t">
+        <di:waypoint x="390" y="225" />
+        <di:waypoint x="450" y="225" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kbumzp_di" bpmnElement="Flow_0kbumzp">
+        <di:waypoint x="248" y="225" />
+        <di:waypoint x="290" y="225" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="212" y="207" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="250" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1a5ox0j_di" bpmnElement="Activity_0a7hels">
+        <dc:Bounds x="290" y="185" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05ujwws_di" bpmnElement="Activity_1neh8m1" isExpanded="true">
+        <dc:Bounds x="450" y="80" width="510" height="320" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lzo5zw_di" bpmnElement="Flow_0lzo5zw">
+        <di:waypoint x="770" y="245" />
+        <di:waypoint x="770" y="330" />
+        <di:waypoint x="872" y="330" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="778" y="285" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bp4b07_di" bpmnElement="Flow_0bp4b07">
+        <di:waypoint x="795" y="220" />
+        <di:waypoint x="872" y="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="824" y="202" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jze8zi_di" bpmnElement="Flow_1jze8zi">
+        <di:waypoint x="518" y="220" />
+        <di:waypoint x="580" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ibrle_di" bpmnElement="Flow_19ibrle">
+        <di:waypoint x="680" y="220" />
+        <di:waypoint x="745" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0nrb96x_di" bpmnElement="Activity_1a7lifm">
+        <dc:Bounds x="580" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1riaxno_di" bpmnElement="Event_1riaxno">
+        <dc:Bounds x="872" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="846" y="245" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c2kswe_di" bpmnElement="Event_0c2kswe">
+        <dc:Bounds x="482" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="472" y="245" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0k7901b_di" bpmnElement="Gateway_0k7901b" isMarkerVisible="true">
+        <dc:Bounds x="745" y="195" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="740" y="156" width="61" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0276x3q_di" bpmnElement="Event_0206bt7">
+        <dc:Bounds x="872" y="312" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="845" y="355" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0fhnwbl_di" bpmnElement="Event_0fhnwbl">
+        <dc:Bounds x="1022" y="452" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1009" y="495" width="62" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_152ucof_di" bpmnElement="Event_152ucof">
+        <dc:Bounds x="1022" y="207" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1010" y="250" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05qv9kd_di" bpmnElement="Event_15ycupq">
+        <dc:Bounds x="872" y="382" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="797" y="425" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -153,6 +153,10 @@ func DeployModel(client zbc.Client, fileName string) (int64, error) {
 		return 0, err
 	}
 
+	return DeployModelBytes(client, fileName, bpmnBytes)
+}
+
+func DeployModelBytes(client zbc.Client, fileName string, bpmnBytes []byte) (int64, error) {
 	LogVerbose("Deploy file %s (size: %d bytes).", fileName, len(bpmnBytes))
 
 	response, err := client.NewDeployProcessCommand().AddResource(bpmnBytes, fileName).Send(context.TODO())
@@ -224,6 +228,28 @@ func DeployDifferentVersions(client zbc.Client, versions int32) error {
 		LogVerbose("Deployed [%d/%d] versions.", count, versions)
 	}
 
+	return nil
+}
+
+func DeployChaosModels(client zbc.Client) error {
+	dirEntries, err := bpmnContent.ReadDir("bpmn/chaos")
+	if err != nil {
+		return err
+	}
+
+	for _, dirEntry := range dirEntries {
+		path := fmt.Sprintf("bpmn/chaos/%s", dirEntry.Name())
+
+		bpmnBytes, err := bpmnContent.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		_, err = DeployModelBytes(client, path, bpmnBytes)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Allows to bundle the chaos experiments with zbchaos and deploy them via `zbchaos deploy chaos` command.

This simplifies the testing of them and we can use that in the k8 deployment to first deploy the models and then start the worker.