### PR TITLE
Worker for read chaos experiments

### DIFF
--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -25,7 +25,8 @@ import (
 	worker "github.com/zeebe-io/zeebe-chaos/go-chaos/worker"
 )
 
-const jobType = "zbchaos"
+const jobTypeZbChaos = "zbchaos"
+const jobTypeReadExperiments = "readExperiments"
 
 func init() {
 	rootCmd.AddCommand(workerCommand)
@@ -54,7 +55,8 @@ func start_worker(cmd *cobra.Command, args []string) {
 	}
 
 	// Allow only one job at a time, otherwise job handling might interfere (e.g. override global vars)
-	jobWorker := client.NewJobWorker().JobType(jobType).Handler(handleZbChaosJob).MaxJobsActive(1).Open()
+	jobWorker := client.NewJobWorker().JobType(jobTypeZbChaos).Handler(handleZbChaosJob).MaxJobsActive(1).Open()
+	client.NewJobWorker().JobType(jobTypeReadExperiments).Handler(handleZbChaosJob).MaxJobsActive(1).Open()
 	jobWorker.AwaitClose()
 }
 

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/leader-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart gracefully experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should recover after a partition leader was restarted gracefully.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/leader-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/leader-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. We expect that Zeebe can handle non-graceful leader restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/msg-correlation/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/msg-correlation/experiment.json
@@ -1,0 +1,56 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe message correlation experiment",
+    "description": "Zeebe message correlation should work even if the leader was restarted on which the message was published.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Publish message to partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "publish-message.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        },
+        {
+                "name": "Should be able to create a process and await the message correlation",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-message-correlation.sh",
+                    "timeout": 900
+                }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/multiple-leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/multiple-leader-restart/experiment.json
@@ -1,0 +1,110 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart multiple times experiment",
+    "description": "Zeebe should be able to handle multiple leader changes in short period.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition one",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/stress-cpu-on-broker/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/stress-cpu-on-broker/experiment.json
@@ -1,0 +1,46 @@
+{
+    "version": "0.1.0",
+    "title": "CPU stress on an Broker",
+    "description": "The cpu stress on an abritrary node should not cause any failures. We should be able to start and complete instances.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Stress CPU on Broker",
+            "provider": {
+                "type": "process",
+                "path": "stress-cpu.sh"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/development/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/development/worker-restart/experiment.json
@@ -1,0 +1,51 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Worker restart experiment",
+    "description": "Zeebe Workers should be able to reconnect after restart.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create a process and await the result",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-processes-with-result.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart worker pod",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "terminate-workers.sh",
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/deployment-distribution/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/deployment-distribution/experiment.json
@@ -1,0 +1,106 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe deployment distribution",
+    "description": "Zeebe deployment distribution should be fault-tolerant. Zeebe should be able to handle network outages and fail-overs and distribute the deployments after partitions are available again.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Enable net_admin capabilities",
+            "provider": {
+                "type": "process",
+                "path": "apply_net_admin.sh"
+            },
+            "pauses": {
+                "after": 180
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Create network partition between leaders",
+            "provider": {
+                "type": "process",
+                "path": "disconnect-leaders-one-way.sh"
+            }
+        },
+        {
+            "type": "action",
+            "name": "Deploy different deployment versions.",
+            "provider": {
+                "type": "process",
+                "path": "deploy-different-versions.sh",
+                "arguments": ["Follower", "3"]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Delete network partition",
+            "provider": {
+                "type": "process",
+                "path": "connect-leaders.sh"
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["1", "10"],
+                "timeout": 900
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition two",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["2", "10"],
+                "timeout": 900
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition three",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["3", "10"],
+                "timeout": 900
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/follower-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/follower-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower graceful restart experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle follower restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart follower of partition 3 gracefully",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": ["Follower", "3"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/follower-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/follower-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle followers terminations.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate follower of partition 3",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Follower", "3"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/leader-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart gracefully experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should recover after a partition leader was restarted gracefully.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 3",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": [ "Leader", "3" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/leader-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/leader-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. We expect that Zeebe can handle non-graceful leader restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 3 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "3" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/msg-correlation/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/msg-correlation/experiment.json
@@ -1,0 +1,56 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe message correlation experiment",
+    "description": "Zeebe message correlation should work even if the leader was restarted on which the message was published.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Publish message to partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "publish-message.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        },
+        {
+                "name": "Should be able to create a process and await the message correlation",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-message-correlation.sh",
+                    "timeout": 900
+                }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/multiple-leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/multiple-leader-restart/experiment.json
@@ -1,0 +1,110 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart multiple times experiment",
+    "description": "Zeebe should be able to handle multiple leader changes in short period.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition one",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/stress-cpu-on-broker/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/stress-cpu-on-broker/experiment.json
@@ -1,0 +1,46 @@
+{
+    "version": "0.1.0",
+    "title": "CPU stress on an Broker",
+    "description": "The cpu stress on an abritrary node should not cause any failures. We should be able to start and complete instances.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Stress CPU on Broker",
+            "provider": {
+                "type": "process",
+                "path": "stress-cpu.sh"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-l/worker-restart/experiment.json
@@ -1,0 +1,51 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Worker restart experiment",
+    "description": "Zeebe Workers should be able to reconnect after restart.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create a process and await the result",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-processes-with-result.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart worker pod",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "terminate-workers.sh",
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/follower-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/follower-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower graceful restart experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle follower restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart follower of partition 3 gracefully",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": ["Follower", "3"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/follower-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/follower-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle followers terminations.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate follower of partition 3",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Follower", "3"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/leader-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart gracefully experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should recover after a partition leader was restarted gracefully.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 3",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": [ "Leader", "3" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/leader-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/leader-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. We expect that Zeebe can handle non-graceful leader restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 3 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "3" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/msg-correlation/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/msg-correlation/experiment.json
@@ -1,0 +1,56 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe message correlation experiment",
+    "description": "Zeebe message correlation should work even if the leader was restarted on which the message was published.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Publish message to partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "publish-message.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        },
+        {
+                "name": "Should be able to create a process and await the message correlation",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-message-correlation.sh",
+                    "timeout": 900
+                }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/multiple-leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/multiple-leader-restart/experiment.json
@@ -1,0 +1,110 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart multiple times experiment",
+    "description": "Zeebe should be able to handle multiple leader changes in short period.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition one",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/stress-cpu-on-broker/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/stress-cpu-on-broker/experiment.json
@@ -1,0 +1,46 @@
+{
+    "version": "0.1.0",
+    "title": "CPU stress on an Broker",
+    "description": "The cpu stress on an abritrary node should not cause any failures. We should be able to start and complete instances.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 3",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Stress CPU on Broker",
+            "provider": {
+                "type": "process",
+                "path": "stress-cpu.sh"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-m/worker-restart/experiment.json
@@ -1,0 +1,51 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Worker restart experiment",
+    "description": "Zeebe Workers should be able to reconnect after restart.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create a process and await the result",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-processes-with-result.sh",
+                    "arguments": "3",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart worker pod",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "terminate-workers.sh",
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/deployment-distribution/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/deployment-distribution/experiment.json
@@ -1,0 +1,106 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe deployment distribution",
+    "description": "Zeebe deployment distribution should be fault-tolerant. Zeebe should be able to handle network outages and fail-overs and distribute the deployments after partitions are available again.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Enable net_admin capabilities",
+            "provider": {
+                "type": "process",
+                "path": "apply_net_admin.sh"
+            },
+            "pauses": {
+                "after": 180
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Create network partition between leaders",
+            "provider": {
+                "type": "process",
+                "path": "disconnect-leaders-one-way.sh"
+            }
+        },
+        {
+            "type": "action",
+            "name": "Deploy different deployment versions.",
+            "provider": {
+                "type": "process",
+                "path": "deploy-different-versions.sh",
+                "arguments": ["Follower", "3"]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Delete network partition",
+            "provider": {
+                "type": "process",
+                "path": "connect-leaders.sh"
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["1", "10"],
+                "timeout": 900
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition two",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["2", "10"],
+                "timeout": 900
+            }
+        },
+        {
+            "type": "probe",
+            "name": "Create process instance of latest version on partition three",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "start-instance-on-partition-with-version.sh",
+                "arguments": ["3", "10"],
+                "timeout": 900
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower graceful restart experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle follower restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart follower of partition 1 gracefully",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": ["Follower", "1"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe follower restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should be able to handle followers terminations.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate follower of partition 1",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Follower", "1"]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/leader-restart/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart gracefully experiment",
+    "description": "Zeebe should be fault-tolerant. Zeebe should recover after a partition leader was restarted gracefully.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1",
+            "provider": {
+                "type": "process",
+                "path": "shutdown-gracefully-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/leader-terminate/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/leader-terminate/experiment.json
@@ -1,0 +1,47 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart non-graceful experiment",
+    "description": "Zeebe should be fault-tolerant. We expect that Zeebe can handle non-graceful leader restarts.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/msg-correlation/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/msg-correlation/experiment.json
@@ -1,0 +1,56 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe message correlation experiment",
+    "description": "Zeebe message correlation should work even if the leader was restarted on which the message was published.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Publish message to partition one",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "publish-message.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition 1 non-gracefully",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": [ "Leader", "1" ]
+            }
+        },
+        {
+                "name": "Should be able to create a process and await the message correlation",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-message-correlation.sh",
+                    "timeout": 900
+                }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/multiple-leader-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/multiple-leader-restart/experiment.json
@@ -1,0 +1,110 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Leader restart multiple times experiment",
+    "description": "Zeebe should be able to handle multiple leader changes in short period.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition one",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-readiness.sh",
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create process instances on partition one",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "verify-steady-state.sh",
+                "arguments": "1",
+                "timeout": 900
+            }
+        },
+        {
+            "type": "action",
+            "name": "Terminate leader of partition one",
+            "provider": {
+                "type": "process",
+                "path": "terminate-partition.sh",
+                "arguments": ["Leader", "1"],
+                "status": "0"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/stress-cpu-on-broker/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/stress-cpu-on-broker/experiment.json
@@ -1,0 +1,46 @@
+{
+    "version": "0.1.0",
+    "title": "CPU stress on an Broker",
+    "description": "The cpu stress on an abritrary node should not cause any failures. We should be able to start and complete instances.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-steady-state.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Stress CPU on Broker",
+            "provider": {
+                "type": "process",
+                "path": "stress-cpu.sh"
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
@@ -1,0 +1,51 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe Worker restart experiment",
+    "description": "Zeebe Workers should be able to reconnect after restart.",
+    "contributions": {
+        "reliability": "high",
+        "availability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "verify-readiness.sh",
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create a process and await the result",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "await-processes-with-result.sh",
+                    "arguments": "1",
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "type": "action",
+            "name": "Restart worker pod",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "terminate-workers.sh",
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+        }
+    ],
+    "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/chaos_experiments.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments.go
@@ -1,0 +1,43 @@
+package chaos_experiments
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// chaosContent holds our static camunda cloud chaos experiments, which are copied with the go:embed directive
+//
+//go:embed camunda-cloud/*
+var chaosContent embed.FS
+
+const experimentFileName = "experiment.json"
+
+func readExperimentsForClusterPlan(clusterPlan string) (string, error) {
+	normalizedClusterPlan := strings.ToLower(strings.Replace(clusterPlan, " ", "", -1))
+	rootPath := fmt.Sprintf("camunda-cloud/%s", normalizedClusterPlan)
+	dirEntries, err := chaosContent.ReadDir(rootPath)
+	if err != nil {
+		return "", err
+	}
+
+	var experiments []map[string]interface{}
+	for _, dir := range dirEntries {
+		if dir.IsDir() {
+			experimentBytes, err := chaosContent.ReadFile(fmt.Sprintf("%s/%s/%s", rootPath, dir.Name(), experimentFileName))
+			if err != nil {
+				return "", err
+			}
+			var jsonObj map[string]interface{}
+			err = json.Unmarshal(experimentBytes, &jsonObj)
+			if err != nil {
+				return "", err
+			}
+			experiments = append(experiments, jsonObj)
+		}
+	}
+
+	jsonBytes, err := json.Marshal(experiments)
+	return string(jsonBytes), err
+}

--- a/go-chaos/internal/chaos-experiments/chaos_experiments.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments.go
@@ -14,30 +14,33 @@ var chaosContent embed.FS
 
 const experimentFileName = "experiment.json"
 
-func readExperimentsForClusterPlan(clusterPlan string) (string, error) {
+type Experiments struct {
+	Experiments []map[string]interface{}
+}
+
+func ReadExperimentsForClusterPlan(clusterPlan string) (Experiments, error) {
 	normalizedClusterPlan := strings.ToLower(strings.Replace(clusterPlan, " ", "", -1))
 	rootPath := fmt.Sprintf("camunda-cloud/%s", normalizedClusterPlan)
 	dirEntries, err := chaosContent.ReadDir(rootPath)
 	if err != nil {
-		return "", err
+		return Experiments{}, err
 	}
 
-	var experiments []map[string]interface{}
+	experiments := Experiments{}
 	for _, dir := range dirEntries {
 		if dir.IsDir() {
 			experimentBytes, err := chaosContent.ReadFile(fmt.Sprintf("%s/%s/%s", rootPath, dir.Name(), experimentFileName))
 			if err != nil {
-				return "", err
+				return experiments, err
 			}
 			var jsonObj map[string]interface{}
 			err = json.Unmarshal(experimentBytes, &jsonObj)
 			if err != nil {
-				return "", err
+				return experiments, err
 			}
-			experiments = append(experiments, jsonObj)
+			experiments.Experiments = append(experiments.Experiments, jsonObj)
 		}
 	}
 
-	jsonBytes, err := json.Marshal(experiments)
-	return string(jsonBytes), err
+	return experiments, err
 }

--- a/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
@@ -1,0 +1,32 @@
+package chaos_experiments
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Experiment struct {
+	Version string
+	Title   string
+}
+
+func Test_ShouldReadExperiments(t *testing.T) {
+	// given
+
+	// when
+	experimentsForClusterPlan, err := readExperimentsForClusterPlan("Production - S")
+
+	// then
+	require.NoError(t, err)
+	assert.NotNil(t, experimentsForClusterPlan)
+
+	var experiments []Experiment
+	err = json.Unmarshal([]byte(experimentsForClusterPlan), &experiments)
+	require.NoError(t, err)
+	assert.Greater(t, len(experiments), 2)
+	assert.NotEqual(t, experiments[0], experiments[1])
+	assert.NotEqual(t, "Zeebe deployment distribution", experiments[0])
+}

--- a/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
@@ -1,32 +1,24 @@
 package chaos_experiments
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type Experiment struct {
-	Version string
-	Title   string
-}
-
 func Test_ShouldReadExperiments(t *testing.T) {
 	// given
 
 	// when
-	experimentsForClusterPlan, err := readExperimentsForClusterPlan("Production - S")
+	experimentsForClusterPlan, err := ReadExperimentsForClusterPlan("Production - S")
 
 	// then
 	require.NoError(t, err)
 	assert.NotNil(t, experimentsForClusterPlan)
 
-	var experiments []Experiment
-	err = json.Unmarshal([]byte(experimentsForClusterPlan), &experiments)
 	require.NoError(t, err)
-	assert.Greater(t, len(experiments), 2)
-	assert.NotEqual(t, experiments[0], experiments[1])
-	assert.NotEqual(t, "Zeebe deployment distribution", experiments[0])
+	assert.Greater(t, len(experimentsForClusterPlan.Experiments), 2)
+	assert.NotEqual(t, experimentsForClusterPlan.Experiments[0], experimentsForClusterPlan.Experiments[1])
+	assert.NotEqual(t, "Zeebe deployment distribution", experimentsForClusterPlan.Experiments[0])
 }

--- a/go-chaos/worker/fake.go
+++ b/go-chaos/worker/fake.go
@@ -30,6 +30,7 @@ type FakeJobClient struct {
 	ErrorMsg   string
 	Failed     bool
 	Succeeded  bool
+	Variables  interface{}
 }
 
 type FakeCompleteClient struct {
@@ -51,6 +52,11 @@ func (f *FakeCompleteClient) JobKey(key int64) commands.CompleteJobCommandStep2 
 
 func (f *FakeCompleteClient) Send(ctx context.Context) (*pb.CompleteJobResponse, error) {
 	return &pb.CompleteJobResponse{}, nil
+}
+
+func (f *FakeCompleteClient) VariablesFromObject(v interface{}) (commands.DispatchCompleteJobCommand, error) {
+	f.JobClient.Variables = v
+	return f, nil
 }
 
 // Fake FAIL Client
@@ -75,6 +81,11 @@ func (f *FakeFailClient) JobKey(key int64) commands.FailJobCommandStep2 {
 
 func (f *FakeFailClient) Retries(retries int32) commands.FailJobCommandStep3 {
 	f.JobClient.RetriesVal = int(retries)
+	return f
+}
+
+func (f *FakeFailClient) ErrorMessage(errorMsg string) commands.FailJobCommandStep3 {
+	f.JobClient.ErrorMsg = errorMsg
 	return f
 }
 


### PR DESCRIPTION
Replacement of old Kotlin worker which has read the experiments, see https://github.com/zeebe-io/zeebe-chaos/blob/main/chaos-workers/chaos-worker/src/main/kotlin/io/zeebe/chaos/ReadChaosExperimentsHandler.kt

The Camunda cloud experiments are now bundled into zbchaos, allowing it to be next to the code and not fail experiments when changing something in the repo. This means experiments are versioned with zbchaos now. 

Added new tests and extended the fake job client to write better tests.

closes #236 



