### PR TITLE
fix: Do not wait for all pods to be ready in dataloss recovery

### DIFF
--- a/go-chaos/internal/dataloss_sim_helper.go
+++ b/go-chaos/internal/dataloss_sim_helper.go
@@ -73,7 +73,7 @@ func (c K8Client) ApplyInitContainerPatch() error {
               "-c"
             ],
             "args": [
-              "while true; do block=$(cat /etc/config/block_${K8S_NAME##*-}); if [ $block == \"false\" ]; then break; fi; echo "Startup is blocked."; sleep 10; done"
+              "while true; do block=$(cat /etc/config/block_${K8S_NAME##*-}); if [ $block == \"false\" ]; then break; fi; echo \"Startup is blocked.\"; sleep 10; done"
             ],
             "env": [
               {


### PR DESCRIPTION
When recovering after dataloss, there might be other brokers which are not yet recovered. So we cannot wait for all brokers to be ready.