### PR TITLE
ci: build a snapshot image of zbchaos

### DIFF
--- a/.github/workflows/publishZbchaosImage.yml
+++ b/.github/workflows/publishZbchaosImage.yml
@@ -1,6 +1,8 @@
 name: Release zbchaos Docker Image
 on:
   pull_request: {} 
+  push:
+    branches: [ main ]
   release:
     types: [published]
 


### PR DESCRIPTION
This is useful for testing and no need to wait until the release. The image is not tagged as SNAPSHOT but with the commit sha.