### PR TITLE
Enable json logging for worker

### DIFF
--- a/go-chaos/Dockerfile
+++ b/go-chaos/Dockerfile
@@ -17,4 +17,4 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/zbchaos /usr/local/bin/
 
 ENTRYPOINT ["zbchaos"]
-CMD ["worker"]
+CMD ["worker", "--jsonLogging", "--verbose"]

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -54,6 +54,8 @@ func start_worker(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	internal.LogVerbose("Open workers: [%s, %s].", jobTypeZbChaos, jobTypeReadExperiments)
+
 	// Allow only one job at a time, otherwise job handling might interfere (e.g. override global vars)
 	jobWorker := client.NewJobWorker().JobType(jobTypeZbChaos).Handler(handleZbChaosJob).MaxJobsActive(1).Open()
 	client.NewJobWorker().JobType(jobTypeReadExperiments).Handler(handleZbChaosJob).MaxJobsActive(1).Open()


### PR DESCRIPTION
Turn on json logging for worker docker image, so we have better logging output