### PR TITLE
Experiments need to start with lower letter

### DIFF
--- a/go-chaos/internal/chaos-experiments/chaos_experiments.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments.go
@@ -15,7 +15,7 @@ var chaosContent embed.FS
 const experimentFileName = "experiment.json"
 
 type Experiments struct {
-	Experiments []map[string]interface{}
+	Experiments []map[string]interface{} `json:"experiments"`
 }
 
 func ReadExperimentsForClusterPlan(clusterPlan string) (Experiments, error) {

--- a/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
+++ b/go-chaos/internal/chaos-experiments/chaos_experiments_test.go
@@ -1,6 +1,7 @@
 package chaos_experiments
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +22,18 @@ func Test_ShouldReadExperiments(t *testing.T) {
 	assert.Greater(t, len(experimentsForClusterPlan.Experiments), 2)
 	assert.NotEqual(t, experimentsForClusterPlan.Experiments[0], experimentsForClusterPlan.Experiments[1])
 	assert.NotEqual(t, "Zeebe deployment distribution", experimentsForClusterPlan.Experiments[0])
+}
+
+func Test_ShouldBeAbleToMarshalExperiments(t *testing.T) {
+	// given
+
+	// when
+	experimentsForClusterPlan, err := ReadExperimentsForClusterPlan("Production - S")
+
+	// then
+	marshal, err := json.Marshal(experimentsForClusterPlan)
+	require.NoError(t, err)
+
+	// experiments key should be small
+	assert.Contains(t, string(marshal), "experiments")
 }


### PR DESCRIPTION
Set json annotation to marshal the experiments into correct key, with small letters.