### PR TITLE
Migrate follower restart experiment

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -30,7 +30,7 @@ var (
 	role               string
 	nodeId             int
 	processModelPath   string
-	multipleVersions   int
+	versionCount       int
 	variables          string
 	msgName            string
 	awaitResult        bool

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/deployment-distribution/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/deployment-distribution/experiment.json
@@ -39,7 +39,7 @@
             "provider": {
                 "type": "process",
                 "path": "zbchaos",
-                "arguments": ["deploy", "process", "--multipleVersions", "10"],
+                "arguments": ["deploy", "multi-version", "--versionCount", "10"],
                 "timeout": 900
             }
         },

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/follower-restart/experiment.json
@@ -15,7 +15,19 @@
                 "tolerance": 0,
                 "provider": {
                     "type": "process",
-                    "path": "verify-readiness.sh",
+                    "path": "zbchaos",
+                    "arguments": ["verify", "readiness"],
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Can deploy process model",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "zbchaos",
+                    "arguments": ["deploy", "process"],
                     "timeout": 900
                 }
             },
@@ -25,8 +37,8 @@
                 "tolerance": 0,
                 "provider": {
                     "type": "process",
-                    "path": "verify-steady-state.sh",
-                    "arguments": "1",
+                    "path": "zbchaos",
+                    "arguments": ["verify", "instance-creation", "--partitionId", "1"],
                     "timeout": 900
                 }
             }
@@ -38,8 +50,8 @@
             "name": "Restart follower of partition 1 gracefully",
             "provider": {
                 "type": "process",
-                "path": "shutdown-gracefully-partition.sh",
-                "arguments": ["Follower", "1"]
+                "path": "zbchaos",
+                "arguments": ["restart", "broker", "--role", "FOLLOWER", "--partitionId", "1"]
             }
         }
     ],

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -284,10 +284,9 @@ type ProcessInstanceCreationOptions struct {
 
 func CreateProcessInstanceCreator(zbClient zbc.Client, options ProcessInstanceCreationOptions) (ProcessInstanceCreator, error) {
 	var processInstanceCreator ProcessInstanceCreator
-	LogVerbose("Create process instance with BPMN process ID %s and version %d [variables: '%s', awaitResult: %t]",
-		options.BpmnProcessId, options.Version, options.Variables, options.AwaitResult)
-
 	processInstanceCreator = func() (int64, error) {
+		LogVerbose("Send create process instance command, with BPMN process ID '%s' and version '%d' (-1 means latest) [variables: '%s', awaitResult: %t]",
+			options.BpmnProcessId, options.Version, options.Variables, options.AwaitResult)
 		commandStep3 := zbClient.NewCreateInstanceCommand().BPMNProcessId(options.BpmnProcessId).Version(options.Version)
 		if len(options.Variables) != 0 {
 			_, err := commandStep3.VariablesFromString(options.Variables)

--- a/go-chaos/worker/chaos_worker.go
+++ b/go-chaos/worker/chaos_worker.go
@@ -76,11 +76,15 @@ func HandleZbChaosJob(client worker.JobClient, job entities.Job, commandRunner C
 
 	err = commandRunner(commandArgs, commandCtx)
 	if err != nil {
+		internal.LogInfo("Error on running command. [key: %d, args: %s]. Error: %s", job.Key, commandArgs, err.Error())
 		_, _ = client.NewFailJobCommand().JobKey(job.Key).Retries(job.Retries - 1).Send(ctx)
 		return
 	}
 
-	_, _ = client.NewCompleteJobCommand().JobKey(job.Key).Send(ctx)
+	_, err = client.NewCompleteJobCommand().JobKey(job.Key).Send(ctx)
+	if err != nil {
+		internal.LogInfo("Error on completing the job [key: %d]. Error: %s", job.Key, err.Error())
+	}
 }
 
 func HandleReadExperiments(client worker.JobClient, job entities.Job) {


### PR DESCRIPTION
:white_check_mark: Depends on #268 

related to https://github.com/zeebe-io/zeebe-chaos/issues/237

------------

Migrates the follower restart experiment and tested with integration test

Log output:


```
Deploy file bpmn/chaos/actionRunner.bpmn (size: 8788 bytes).
Deployed process model bpmn/chaos/actionRunner.bpmn successful with key 2251799813685249.
Deploy file bpmn/chaos/chaosExperiment.bpmn (size: 21403 bytes).
Deployed process model bpmn/chaos/chaosExperiment.bpmn successful with key 2251799813685251.
Deploy file bpmn/chaos/chaosToolkit.bpmn (size: 11031 bytes).
Deployed process model bpmn/chaos/chaosToolkit.bpmn successful with key 2251799813685253.
Create ChaosToolkit instance
Open workers: [zbchaos, readExperiments].
Handle read experiments job [key: 2251799813685265]
Read experiments successful, complete job with: {"experiments":[{"contributions":{"availability":"high","reliability":"high"},"description":"Zeebe should be fault-tolerant. Zeebe should be able to handle follower restarts.","method":[{"name":"Restart follower of partition 1 gracefully","provider":{"arguments":["restart","broker","--role","FOLLOWER","--partitionId","1"],"path":"zbchaos","type":"process"},"type":"action"}],"rollbacks":[],"steady-state-hypothesis":{"probes":[{"name":"All pods should be ready","provider":{"arguments":["verify","readiness"],"path":"zbchaos","timeout":900,"type":"process"},"tolerance":0,"type":"probe"},{"name":"Can deploy process model","provider":{"arguments":["deploy","process"],"path":"zbchaos","timeout":900,"type":"process"},"tolerance":0,"type":"probe"},{"name":"Should be able to create process instances on partition 1","provider":{"arguments":["verify","instance-creation","--partitionId","1"],"path":"zbchaos","timeout":900,"type":"process"},"tolerance":0,"type":"probe"}],"title":"Zeebe is alive"},"title":"Zeebe follower graceful restart experiment","version":"0.1.0"},{"contributions":{"availability":"high","reliability":"high"},"description":"This fake experiment is just to test the integration with Zeebe and zbchaos workers","method":[{"name":"Show again the version","pauses":{"after":5},"provider":{"arguments":["version"],"path":"zbchaos","timeout":900,"type":"process"},"tolerance":0,"type":"action"}],"rollbacks":[],"steady-state-hypothesis":{"probes":[{"name":"Show version","provider":{"arguments":["version"],"path":"zbchaos","timeout":900,"type":"process"},"tolerance":0,"type":"probe"}],"title":"Zeebe is alive"},"title":"This is a fake experiment","version":"0.1.0"}]}.
Handle zbchaos job [key: 2251799813685328]
Running command with args: [verify readiness] 
Connecting to zell-chaos
Running experiment in self-managed environment.
All Zeebe nodes are running.
Handle zbchaos job [key: 2251799813685380]
Running command with args: [deploy process] 
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Deploy file bpmn/one_task.bpmn (size: 2526 bytes).
Deployed process model bpmn/one_task.bpmn successful with key 2251799813685431.
Deployed given process model , under key 2251799813685431!
Handle zbchaos job [key: 2251799813685424]
Running command with args: [verify instance-creation --partitionId 1] 
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 4503599627371757 on partition 2, required partition 1.
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 6755399441057008 on partition 3, required partition 1.
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 2251799813686572 on partition 1, required partition 1.
The steady-state was successfully verified!
Handle zbchaos job [key: 2251799813685472]
Running command with args: [restart broker --role FOLLOWER --partitionId 1] 
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Found Broker zell-chaos-zeebe-2 as FOLLOWER for partition 1.
Restarted zell-chaos-zeebe-2
Handle zbchaos job [key: 2251799813685518]
Running command with args: [verify readiness] 
Connecting to zell-chaos
Running experiment in self-managed environment.
All Zeebe nodes are running.
Handle zbchaos job [key: 2251799813685559]
Running command with args: [deploy process] 
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Deploy file bpmn/one_task.bpmn (size: 2526 bytes).
Deployed process model bpmn/one_task.bpmn successful with key 2251799813685431.
Deployed given process model , under key 2251799813685431!
Handle zbchaos job [key: 2251799813685603]
Running command with args: [verify instance-creation --partitionId 1] 
Connecting to zell-chaos
Running experiment in self-managed environment.
Successfully created port forwarding tunnel
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 4503599627371783 on partition 2, required partition 1.
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 6755399441057035 on partition 3, required partition 1.
Send create process instance command, with BPMN process ID 'benchmark' and version '-1' (-1 means latest) [variables: '', awaitResult: false]
Created process instance with key 2251799813686599 on partition 1, required partition 1.
The steady-state was successfully verified!
Handle zbchaos job [key: 2251799813685698]
Running command with args: [version] 
zbchaos development (commit: HEAD)
Handle zbchaos job [key: 2251799813685740]
Running command with args: [version] 
zbchaos development (commit: HEAD)
Handle zbchaos job [key: 2251799813685885]
Running command with args: [version] 
zbchaos development (commit: HEAD)
Instance 2251799813685255 [definition 2251799813685253 ] completed
--- PASS: Test_ShouldBeAbleToRunExperiments (12.03s)


```