### PR TITLE
Add logging context

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -50,7 +49,6 @@ var ClientId string
 var ClientSecret string
 var Audience string
 var JsonLogging bool
-var LoggingContext string
 
 var rootCmd = &cobra.Command{
 	Use:   "zbchaos",
@@ -61,13 +59,7 @@ var rootCmd = &cobra.Command{
 		internal.Verbosity = Verbose
 		internal.JsonLogging = JsonLogging
 		if JsonLogging {
-			if LoggingContext != "" {
-				// should be json
-				ctxObj := make(map[string]interface{})
-				err := json.Unmarshal([]byte(LoggingContext), &ctxObj)
-				ensureNoError(err)
-				internal.JsonLogger = log.With().Fields(ctxObj).Logger()
-			}
+			internal.JsonLogger = log.With().Logger()
 		}
 		internal.Namespace = Namespace
 		internal.KubeConfigPath = KubeConfigPath
@@ -84,7 +76,6 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
-	rootCmd.PersistentFlags().StringVar(&LoggingContext, "loggingContext", "", "the (optional) context which can be set for json logging, should be a json object")
 	rootCmd.PersistentFlags().StringVar(&KubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "connect to the given namespace")
 	rootCmd.PersistentFlags().StringVarP(&ClientId, "clientId", "c", "", "connect using the given clientId")

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -49,6 +50,7 @@ var ClientId string
 var ClientSecret string
 var Audience string
 var JsonLogging bool
+var LoggingContext string
 
 var rootCmd = &cobra.Command{
 	Use:   "zbchaos",
@@ -59,7 +61,13 @@ var rootCmd = &cobra.Command{
 		internal.Verbosity = Verbose
 		internal.JsonLogging = JsonLogging
 		if JsonLogging {
-			internal.JsonLogger = log.With().Str("cli", "zbchaos").Logger()
+			if LoggingContext != "" {
+				// should be json
+				ctxObj := make(map[string]interface{})
+				err := json.Unmarshal([]byte(LoggingContext), &ctxObj)
+				ensureNoError(err)
+				internal.JsonLogger = log.With().Fields(ctxObj).Logger()
+			}
 		}
 		internal.Namespace = Namespace
 		internal.KubeConfigPath = KubeConfigPath
@@ -76,6 +84,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
+	rootCmd.PersistentFlags().StringVar(&LoggingContext, "loggingContext", "", "the (optional) context which can be set for json logging, should be a json object")
 	rootCmd.PersistentFlags().StringVar(&KubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "connect to the given namespace")
 	rootCmd.PersistentFlags().StringVarP(&ClientId, "clientId", "c", "", "connect using the given clientId")

--- a/go-chaos/integration/integration_test.go
+++ b/go-chaos/integration/integration_test.go
@@ -49,6 +49,7 @@ func Test_ShouldBeAbleToRunExperiments(t *testing.T) {
 	// given
 	internal.Verbosity = true
 	cmd.Verbose = true
+	cmd.JsonLogging = true
 	ctx := context.Background()
 	container := CreateEZEContainer(t, ctx)
 	defer container.StopLogProducer()

--- a/go-chaos/internal/logging.go
+++ b/go-chaos/internal/logging.go
@@ -18,10 +18,16 @@ import (
 	"fmt"
 )
 
+var LoggingContext map[string]interface{}
+
 func LogVerbose(text string, a ...any) {
 	if Verbosity {
 		if JsonLogging {
-			JsonLogger.Debug().Msgf(text, a...)
+			debug := JsonLogger.Debug()
+			if LoggingContext != nil {
+				debug = debug.Fields(LoggingContext)
+			}
+			debug.Msgf(text, a...)
 		} else {
 			fmt.Printf(text, a...)
 			fmt.Println()
@@ -31,7 +37,11 @@ func LogVerbose(text string, a ...any) {
 
 func LogInfo(text string, a ...any) {
 	if JsonLogging {
-		JsonLogger.Debug().Msgf(text, a...)
+		info := JsonLogger.Info()
+		if LoggingContext != nil {
+			info.Fields(LoggingContext)
+		}
+		info.Msgf(text, a...)
 	} else {
 		fmt.Printf(text, a...)
 		fmt.Println()

--- a/go-chaos/worker/chaos_worker.go
+++ b/go-chaos/worker/chaos_worker.go
@@ -77,6 +77,9 @@ func HandleZbChaosJob(client worker.JobClient, job entities.Job, commandRunner C
 	// we set here the current log context, this only works if we handle on job per time (which we currently have configured)
 	// TODO make it more thread local
 	internal.LoggingContext = loggingCtx
+	defer func() {
+		internal.LoggingContext = nil
+	}() // reset the context
 	internal.LogInfo("Handle zbchaos job [key: %d]", job.Key)
 
 	timeout := time.Duration(jobVariables.Provider.Timeout) * time.Second

--- a/go-chaos/worker/chaos_worker.go
+++ b/go-chaos/worker/chaos_worker.go
@@ -103,10 +103,13 @@ func HandleZbChaosJob(client worker.JobClient, job entities.Job, commandRunner C
 
 func createLoggingContext(jobVariables ZbChaosVariables, job entities.Job) map[string]interface{} {
 	loggingCtx := make(map[string]interface{})
-	loggingCtx["clusterId"] = *jobVariables.ClusterId
-	loggingCtx["jobKey"] = fmt.Sprintf("%d", job.Key)
-	loggingCtx["processInstanceKey"] = fmt.Sprintf("%d", job.ProcessInstanceKey)
-	loggingCtx["title"] = *jobVariables.Title
+	loggingCtx["logging.googleapis.com/labels"] = map[string]string{
+		"clusterId":          *jobVariables.ClusterId,
+		"jobKey":             fmt.Sprintf("%d", job.Key),
+		"processInstanceKey": fmt.Sprintf("%d", job.ProcessInstanceKey),
+		"title":              *jobVariables.Title,
+	}
+	loggingCtx["logging.googleapis.com/operation"] = map[string]string{"id": fmt.Sprintf("%d", job.Key)}
 	return loggingCtx
 }
 

--- a/go-chaos/worker/chaos_worker_test.go
+++ b/go-chaos/worker/chaos_worker_test.go
@@ -97,8 +97,7 @@ func Test_ShouldHandleCommand(t *testing.T) {
 		"--clientSecret", "clientSecret",
 		"--audience", "audience",
 		"disconnect", "gateway",
-		"--all",
-		"--loggingContext", "{\"clusterId\":\"clusterId\",\"jobKey\":\"123\",\"processInstanceKey\":\"456\",\"title\":\"Fake experiment\"}"}
+		"--all"}
 	assert.Equal(t, expectedArgs, appliedArgs)
 }
 
@@ -133,8 +132,7 @@ func Test_ShouldHandleCommandForSelfManagedWhenNoClusterId(t *testing.T) {
 	assert.Equal(t, 123, fakeJobClient.Key)
 	var expectedArgs = []string{
 		"disconnect", "gateway",
-		"--all",
-		"--loggingContext", "{\"clusterId\":\"\",\"jobKey\":\"123\",\"processInstanceKey\":\"456\",\"title\":\"Fake experiment\"}"}
+		"--all"}
 	assert.Equal(t, expectedArgs, appliedArgs)
 }
 
@@ -211,8 +209,7 @@ func Test_ShouldFailJobWhenHandleFails(t *testing.T) {
 		"--clientSecret", "clientSecret",
 		"--audience", "audience",
 		"disconnect", "gateway",
-		"--all",
-		"--loggingContext", "{\"clusterId\":\"clusterId\",\"jobKey\":\"123\",\"processInstanceKey\":\"456\",\"title\":\"Fake experiment\"}"}
+		"--all"}
 	assert.Equal(t, expectedArgs, appliedArgs)
 }
 


### PR DESCRIPTION
NEW

Add a logging context, which can be set by the workers to enrich our json logs with more useful information, like process instance key, experiment title etc.

The context is set at the begin of the run zbchaos handler and removed again. See https://github.com/zeebe-io/zeebe-chaos/pull/273#issuecomment-1340664349


-----------
OLD

Add a new parameter `--loggingContext` to the root command to set the logging context. 

This is used by the workers to enrich the logging with details like processInstanceKey, experiment name, etc. This is really useful for debugging since we can group and filter the logging better in stackdriver.

Adjust the tests related to that. Furthermore add a test to verify that the worker can also run without clusterId, which I use in my local tests.

Integration test output with JSON logging now:

```json
{"level":"debug","clusterId":"","jobKey":"2251799813685328","processInstanceKey":"2251799813685308","title":"This is a fake experiment","time":"2022-12-07T09:26:51+01:00","message":"zbchaos development (commit: HEAD)"}
{"level":"debug","clusterId":"","jobKey":"2251799813685328","processInstanceKey":"2251799813685308","title":"This is a fake experiment","time":"2022-12-07T09:26:51+01:00","message":"Handle zbchaos job [key: 2251799813685374]"}
{"level":"debug","clusterId":"","jobKey":"2251799813685328","processInstanceKey":"2251799813685308","title":"This is a fake experiment","time":"2022-12-07T09:26:51+01:00","message":"Running command with args: [version --loggingContext {\"clusterId\":\"\",\"jobKey\":\"2251799813685374\",\"processInstanceKey\":\"2251799813685354\",\"title\":\"This is a fake experiment\"}] "}
{"level":"debug","clusterId":"","jobKey":"2251799813685374","processInstanceKey":"2251799813685354","title":"This is a fake experiment","time":"2022-12-07T09:26:51+01:00","message":"zbchaos development (commit: HEAD)"}
{"level":"debug","clusterId":"","jobKey":"2251799813685374","processInstanceKey":"2251799813685354","title":"This is a fake experiment","time":"2022-12-07T09:26:56+01:00","message":"Handle zbchaos job [key: 2251799813685517]"}
{"level":"debug","clusterId":"","jobKey":"2251799813685374","processInstanceKey":"2251799813685354","title":"This is a fake experiment","time":"2022-12-07T09:26:56+01:00","message":"Running command with args: [version --loggingContext {\"clusterId\":\"\",\"jobKey\":\"2251799813685517\",\"processInstanceKey\":\"2251799813685497\",\"title\":\"This is a fake experiment\"}] "}
{"level":"debug","clusterId":"","jobKey":"2251799813685517","processInstanceKey":"2251799813685497","title":"This is a fake experiment","time":"2022-12-07T09:26:56+01:00","message":"zbchaos development (commit: HEAD)"}
{"level":"debug","clusterId":"","jobKey":"2251799813685517","processInstanceKey":"2251799813685497","title":"This is a fake experiment","time":"2022-12-07T09:26:56+01:00","message":"Instance 2251799813685255 [definition 2251799813685253 ] completed"}
--- PASS: Test_ShouldBeAbleToRunExperiments (11.96s)
```