### PR TITLE
Migrate worker restart experiment

### DIFF
--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
@@ -15,18 +15,30 @@
                 "tolerance": 0,
                 "provider": {
                     "type": "process",
-                    "path": "verify-readiness.sh",
+                    "path": "zbchaos",
+                    "arguments": ["verify", "readiness"],
                     "timeout": 900
                 }
             },
             {
-                "name": "Should be able to create a process and await the result",
+                "name": "Can deploy process model",
                 "type": "probe",
                 "tolerance": 0,
                 "provider": {
                     "type": "process",
-                    "path": "await-processes-with-result.sh",
-                    "arguments": "1",
+                    "path": "zbchaos",
+                    "arguments": ["deploy", "process"],
+                    "timeout": 900
+                }
+            },
+            {
+                "name": "Should be able to create process instances on partition 1",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "zbchaos",
+                    "arguments": ["verify", "instance-creation", "--partitionId", "1"],
                     "timeout": 900
                 }
             }
@@ -34,16 +46,53 @@
     },
     "method": [
         {
-            "type": "action",
-            "name": "Restart worker pod",
+            "name": "Deploy Workers",
+            "type": "probe",
             "tolerance": 0,
             "provider": {
                 "type": "process",
-                "path": "terminate-workers.sh",
+                "path": "zbchaos",
+                "arguments": ["deploy", "worker"],
                 "timeout": 900
             },
             "pauses": {
                 "after": 5
+            }
+        },
+        {
+            "name": "Should be able to create a process and await the result",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["verify", "instance-creation", "--partitionId", "1", "--awaitResult"],
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Restart Workers",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["restart", "worker"],
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+        },
+        {
+            "name": "Should be able to create a process and await the result",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["verify", "instance-creation", "--partitionId", "1", "--awaitResult"],
+                "timeout": 900
             }
         }
     ],


### PR DESCRIPTION
First fixed an issue with the worker deployments:

In self-managed env the zeebe gateway service is called differently, based on the helm release name.
The release name is in our setups normally also the namespace name, which we use here.

If the worker is already deployed we update the deployment, instead of failing.

+ Added missing tests for it.

Migrated the worker restart experiment related to #237 

Similar to the other migrated experiments I followed same approach as described here https://github.com/zeebe-io/zeebe-chaos/pull/268


> The experiment was executed and verified via the integration test against a self-managed cluster.
> 
> I moved the experiment into the chaos-experiments/camunda-cloud/test/ folder and migrated it, with that approach I was able to execute the experiment with eze and running against my self-managed zell-chaos zeebe cluster.



----------


This is btw the LAST production s experiment to migrate :tada: 