### PR TITLE
Multiple zbchaos fixes

### DIFF
--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 	worker "github.com/zeebe-io/zeebe-chaos/go-chaos/worker"
+	"google.golang.org/grpc"
 )
 
 const jobTypeZbChaos = "zbchaos"
@@ -63,8 +64,10 @@ func start_worker(cmd *cobra.Command, args []string) {
 	}
 
 	client, err := zbc.NewClient(&zbc.ClientConfig{
-		GatewayAddress:      os.Getenv(ENV_ADDRESS),
-		CredentialsProvider: credsProvider,
+		GatewayAddress:         os.Getenv(ENV_ADDRESS),
+		CredentialsProvider:    credsProvider,
+		DialOpts:               []grpc.DialOption{},
+		UsePlaintextConnection: false,
 	})
 
 	if err != nil {

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -71,6 +71,8 @@ func start_worker(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	internal.LogVerbose("Connect to: %s.", os.Getenv(ENV_ADDRESS))
+
 	OpenWorkers(client)
 }
 

--- a/go-chaos/deploy/deployment.yaml
+++ b/go-chaos/deploy/deployment.yaml
@@ -16,7 +16,8 @@ spec:
         app: zbchaos-worker
     spec:
       containers:
-        - image: gcr.io/zeebe-io/zbchaos:latest
+        - image: gcr.io/zeebe-io/zbchaos:dde8fdb18c4fae69701fd19121ae6c05cb261168@sha256:f5398ce503577873a14c3f2a1582adfc452ead365096aef30cebab0128d0b3d8
+          #gcr.io/zeebe-io/zbchaos:latest
           name: zbchaos-worker
           resources:
             limits:

--- a/go-chaos/deploy/deployment.yaml
+++ b/go-chaos/deploy/deployment.yaml
@@ -20,19 +20,36 @@ spec:
           name: zbchaos-worker
           resources:
             limits:
-              cpu: 1000m
-              memory: 512Mi
+              cpu: 4
+              memory: 1Gi
             requests:
-              cpu: 150m
-              memory: 128Mi
+              cpu: 2
+              memory: 500Mi
           volumeMounts:
             - mountPath: /.kube
               name: kubeconfig
+          env:
+            # We use here different names for the environment variables on purpose.
+            # If we use the normal ZEEBE_ environment variables we would run
+            # into conflicts when using multiple zeebe clients, the env vars will always overwrite
+            # direct values
+            - name: CHAOS_AUTOMATION_CLUSTER_AUTHORIZATION_SERVER_URL
+              value: "https://login.cloud.ultrawombat.com/oauth/token"
+            - name: CHAOS_AUTOMATION_CLUSTER_CLIENT_ID
+              value: "S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo"
+            - name: CHAOS_AUTOMATION_CLUSTER_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: clientSecret
+            - name: CHAOS_AUTOMATION_CLUSTER_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: testbench-secrets
+                  key: contactPoint
           envFrom:
             - secretRef:
                 name: zeebe-backup-store-s3
-            - secretRef:
-                name: zbchaos-worker-client-config
       volumes:
         - name: kubeconfig
           secret:

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/worker-restart/experiment.json
@@ -66,7 +66,7 @@
             "provider": {
                 "type": "process",
                 "path": "zbchaos",
-                "arguments": ["verify", "instance-creation", "--partitionId", "1", "--awaitResult"],
+                "arguments": ["verify", "instance-creation", "--awaitResult"],
                 "timeout": 900
             }
         },
@@ -91,7 +91,7 @@
             "provider": {
                 "type": "process",
                 "path": "zbchaos",
-                "arguments": ["verify", "instance-creation", "--partitionId", "1", "--awaitResult"],
+                "arguments": ["verify", "instance-creation", "--awaitResult"],
                 "timeout": 900
             }
         }

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -327,6 +327,8 @@ func CreateProcessInstanceOnPartition(piCreator ProcessInstanceCreator, required
 
 			if partitionId == requiredPartition {
 				return nil
+			} else if requiredPartition == 0 {
+				return nil
 			}
 		}
 	}

--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -31,19 +31,6 @@ import (
 
 func CreateZeebeClient(port int) (zbc.Client, error) {
 	endpoint := fmt.Sprintf("localhost:%d", port)
-	if ZeebeClientCredential != nil {
-		client, err := zbc.NewClient(&zbc.ClientConfig{
-			GatewayAddress:         endpoint,
-			DialOpts:               []grpc.DialOption{},
-			UsePlaintextConnection: false,
-			CredentialsProvider:    ZeebeClientCredential,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return client, nil
-	}
-
 	client, err := zbc.NewClient(&zbc.ClientConfig{
 		GatewayAddress:         endpoint,
 		DialOpts:               []grpc.DialOption{},

--- a/go-chaos/internal/zeebe_test.go
+++ b/go-chaos/internal/zeebe_test.go
@@ -228,6 +228,19 @@ func Test_ShouldSucceedOnCorrectPartition(t *testing.T) {
 	assert.NoError(t, err, "expected no error")
 }
 
+func Test_ShouldSucceedWhenRequiredPartitionIsZero(t *testing.T) {
+	// given
+	dummyCreator := func() (int64, error) {
+		return 4503599627370515, nil
+	}
+
+	// when
+	err := CreateProcessInstanceOnPartition(dummyCreator, 0, 1*time.Second)
+
+	// then
+	assert.NoError(t, err, "expected no error")
+}
+
 func Test_ShouldFindCorrelationKeyForPartition(t *testing.T) {
 	// given
 	expectedPartition := 47


### PR DESCRIPTION
During deploying and running zbchaos with our QA runs we encountered several issues which I fix in this PR.

## Env vars overwrite values

When deploying zbchaos and on the zbchaos worker we need to use different names for the environment variables.

When we using the normal ZEEBE_ environment variables we run into conflicts with using multiple zeebe clients, the env vars will always overwrite direct values.

## Plaintext

When setting the credentials provider we also have to set the UsePlainText to false.

## No credentials provider for inside the cluster

We need no credentials when running against the target cluster since we port forward to the gateway. This means we can remove the credentials usage.

## Await result

The awaiting of the process instances doesn't require the partition id check. Moreover, this is problematic for things like message correlation since a message is correlated only once to a process. 

Remove the partition id check, when `awaitResult` flag is enabled.