### PR TITLE
Encapsulate all commands

### DIFF
--- a/go-chaos/backend/connection.go
+++ b/go-chaos/backend/connection.go
@@ -23,8 +23,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func ConnectBrokers() error {
-	k8Client, err := internal.CreateK8Client()
+func ConnectBrokers(kubeConfigPath string, namespace string) error {
+	k8Client, err := internal.CreateK8Client(kubeConfigPath, namespace)
 	if err != nil {
 		return err
 	}
@@ -55,8 +55,8 @@ func ConnectBrokers() error {
 	return nil
 }
 
-func ConnectGateway() error {
-	k8Client, err := internal.CreateK8Client()
+func ConnectGateway(kubeConfigPath string, namespace string) error {
+	k8Client, err := internal.CreateK8Client(kubeConfigPath, namespace)
 	if err != nil {
 		return err
 	}
@@ -103,8 +103,8 @@ type DisconnectBrokerCfg struct {
 	OneDirection bool
 }
 
-func DisconnectBroker(disconnectBrokerCfg DisconnectBrokerCfg) error {
-	k8Client, err := prepareBrokerDisconnect()
+func DisconnectBroker(kubeConfigPath string, namespace string, disconnectBrokerCfg DisconnectBrokerCfg) error {
+	k8Client, err := prepareBrokerDisconnect(kubeConfigPath, namespace)
 
 	zbClient, closeFn, err := ConnectToZeebeCluster(k8Client)
 	if err != nil {
@@ -138,8 +138,8 @@ type DisconnectGatewayCfg struct {
 	BrokerCfg       Broker
 }
 
-func DisconnectGateway(disconnectGatewayCfg DisconnectGatewayCfg) error {
-	k8Client, zbClient, closeFn, err := prepareGatewayDisconnect()
+func DisconnectGateway(kubeConfigPath string, namespace string, disconnectGatewayCfg DisconnectGatewayCfg) error {
+	k8Client, zbClient, closeFn, err := prepareGatewayDisconnect(kubeConfigPath, namespace)
 	if err != nil {
 		return err
 	}
@@ -173,8 +173,8 @@ func DisconnectGateway(disconnectGatewayCfg DisconnectGatewayCfg) error {
 	return nil
 }
 
-func prepareGatewayDisconnect() (internal.K8Client, zbc.Client, func(), error) {
-	k8Client, err := prepareBrokerDisconnect()
+func prepareGatewayDisconnect(kubeConfigPath string, namespace string) (internal.K8Client, zbc.Client, func(), error) {
+	k8Client, err := prepareBrokerDisconnect(kubeConfigPath, namespace)
 	if err != nil {
 		return k8Client, nil, nil, err
 	}
@@ -199,8 +199,8 @@ func prepareGatewayDisconnect() (internal.K8Client, zbc.Client, func(), error) {
 	return k8Client, zbClient, closeFn, nil
 }
 
-func prepareBrokerDisconnect() (internal.K8Client, error) {
-	k8Client, err := internal.CreateK8Client()
+func prepareBrokerDisconnect(kubeConfigPath string, namespace string) (internal.K8Client, error) {
+	k8Client, err := internal.CreateK8Client(kubeConfigPath, namespace)
 	if err != nil {
 		return internal.K8Client{}, err
 	}

--- a/go-chaos/cmd/connect.go
+++ b/go-chaos/cmd/connect.go
@@ -19,7 +19,7 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/backend"
 )
 
-func AddConnectCmd(rootCmd *cobra.Command) {
+func AddConnectCmd(rootCmd *cobra.Command, flags Flags) {
 	var connect = &cobra.Command{
 		Use:   "connect",
 		Short: "Connect Zeebe nodes",
@@ -31,7 +31,7 @@ func AddConnectCmd(rootCmd *cobra.Command) {
 		Short: "Connect Zeebe Brokers",
 		Long:  `Connect all Zeebe Brokers again, after they have been disconnected.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := backend.ConnectBrokers()
+			err := backend.ConnectBrokers(flags.kubeConfigPath, flags.namespace)
 			ensureNoError(err)
 		},
 	}
@@ -41,7 +41,7 @@ func AddConnectCmd(rootCmd *cobra.Command) {
 		Short: "Connect Zeebe Gateway",
 		Long:  `Connect all Zeebe Gateway again, after it has been disconnected.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := backend.ConnectGateway()
+			err := backend.ConnectGateway(flags.kubeConfigPath, flags.namespace)
 			ensureNoError(err)
 		},
 	}

--- a/go-chaos/cmd/connect.go
+++ b/go-chaos/cmd/connect.go
@@ -19,34 +19,34 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/backend"
 )
 
-func init() {
+func AddConnectCmd(rootCmd *cobra.Command) {
+	var connect = &cobra.Command{
+		Use:   "connect",
+		Short: "Connect Zeebe nodes",
+		Long:  `Connect all Zeebe nodes again, after they have been disconnected uses sub-commands to connect brokers, gateways, etc.`,
+	}
+
+	var connectBrokers = &cobra.Command{
+		Use:   "brokers",
+		Short: "Connect Zeebe Brokers",
+		Long:  `Connect all Zeebe Brokers again, after they have been disconnected.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := backend.ConnectBrokers()
+			ensureNoError(err)
+		},
+	}
+
+	var connectGateway = &cobra.Command{
+		Use:   "gateway",
+		Short: "Connect Zeebe Gateway",
+		Long:  `Connect all Zeebe Gateway again, after it has been disconnected.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := backend.ConnectGateway()
+			ensureNoError(err)
+		},
+	}
+
 	rootCmd.AddCommand(connect)
 	connect.AddCommand(connectBrokers)
 	connect.AddCommand(connectGateway)
-}
-
-var connect = &cobra.Command{
-	Use:   "connect",
-	Short: "Connect Zeebe nodes",
-	Long:  `Connect all Zeebe nodes again, after they have been disconnected uses sub-commands to connect brokers, gateways, etc.`,
-}
-
-var connectBrokers = &cobra.Command{
-	Use:   "brokers",
-	Short: "Connect Zeebe Brokers",
-	Long:  `Connect all Zeebe Brokers again, after they have been disconnected.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := backend.ConnectBrokers()
-		ensureNoError(err)
-	},
-}
-
-var connectGateway = &cobra.Command{
-	Use:   "gateway",
-	Short: "Connect Zeebe Gateway",
-	Long:  `Connect all Zeebe Gateway again, after it has been disconnected.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := backend.ConnectGateway()
-		ensureNoError(err)
-	},
 }

--- a/go-chaos/cmd/dataloss_sim.go
+++ b/go-chaos/cmd/dataloss_sim.go
@@ -34,7 +34,7 @@ func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags Flags) {
 		Short: "Prepare the k8s deployment for dataloss test",
 		Long:  `Prepares the k8s deployment - such as applying patches to statefulsets - to enable applying dataloss commands.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			if err != nil {
 				panic(err)
 			}
@@ -56,7 +56,7 @@ func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags Flags) {
 		Long:  `Delete data of a broker by deleting the pvc and the pod`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			if err != nil {
 				panic(err)
 			}
@@ -87,7 +87,7 @@ func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags Flags) {
 		Long:  `Restart the broker after full data loss, wait until the data is fully recovered`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			if err != nil {
 				panic(err)
 			}

--- a/go-chaos/cmd/dataloss_sim.go
+++ b/go-chaos/cmd/dataloss_sim.go
@@ -15,9 +15,10 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
-	"time"
 )
 
 func init() {
@@ -26,8 +27,8 @@ func init() {
 	datalossCmd.AddCommand(datalossDelete)
 	datalossCmd.AddCommand(datalossRecover)
 
-	datalossDelete.Flags().IntVar(&nodeId, "nodeId", 1, "Specify the id of the broker")
-	datalossRecover.Flags().IntVar(&nodeId, "nodeId", 1, "Specify the id of the broker")
+	datalossDelete.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
+	datalossRecover.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
 }
 
 var datalossCmd = &cobra.Command{
@@ -68,16 +69,16 @@ var datalossDelete = &cobra.Command{
 			panic(err)
 		}
 
-		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(nodeId))
+		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
 
 		if err != nil {
-			internal.LogInfo("Failed to get pod with nodeId %d %s", nodeId, err)
+			internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
 			panic(err)
 		}
 
 		k8Client.DeletePvcOfBroker(pod.Name)
 
-		internal.SetInitContainerBlockFlag(k8Client, nodeId, "true")
+		internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "true")
 		err = k8Client.RestartPod(pod.Name)
 		if err != nil {
 			internal.LogInfo("Failed to restart pod %s", pod.Name)
@@ -99,15 +100,15 @@ var datalossRecover = &cobra.Command{
 			panic(err)
 		}
 
-		err = internal.SetInitContainerBlockFlag(k8Client, nodeId, "false")
+		err = internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "false")
 		if err != nil {
 			panic(err)
 		}
 
-		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(nodeId))
+		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
 
 		if err != nil {
-			internal.LogInfo("Failed to get pod with nodeId %d %s", nodeId, err)
+			internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
 			panic(err)
 		}
 
@@ -118,6 +119,6 @@ var datalossRecover = &cobra.Command{
 			internal.LogInfo("%s", err)
 			panic(err)
 		}
-		internal.LogInfo("Broker %d is recovered", nodeId)
+		internal.LogInfo("Broker %d is recovered", flags.nodeId)
 	},
 }

--- a/go-chaos/cmd/dataloss_sim.go
+++ b/go-chaos/cmd/dataloss_sim.go
@@ -21,7 +21,100 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags Flags) {
+
+	var datalossCmd = &cobra.Command{
+		Use:   "dataloss",
+		Short: "Simulate dataloss and recover",
+		Long:  `Simulate dataloss of a broker, and recover from it.`,
+	}
+
+	var prepareCmd = &cobra.Command{
+		Use:   "prepare",
+		Short: "Prepare the k8s deployment for dataloss test",
+		Long:  `Prepares the k8s deployment - such as applying patches to statefulsets - to enable applying dataloss commands.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			if err != nil {
+				panic(err)
+			}
+
+			// Add Init container for dataloss simulation test
+			err = k8Client.ApplyInitContainerPatch()
+
+			if err != nil {
+				panic(err)
+			}
+
+			internal.LogInfo("Prepared cluster in namesapce %s", k8Client.GetCurrentNamespace())
+		},
+	}
+
+	var datalossDelete = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete data of a broker",
+		Long:  `Delete data of a broker by deleting the pvc and the pod`,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			k8Client, err := internal.CreateK8Client()
+			if err != nil {
+				panic(err)
+			}
+
+			pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
+
+			if err != nil {
+				internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
+				panic(err)
+			}
+
+			k8Client.DeletePvcOfBroker(pod.Name)
+
+			internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "true")
+			err = k8Client.RestartPod(pod.Name)
+			if err != nil {
+				internal.LogInfo("Failed to restart pod %s", pod.Name)
+				panic(err)
+			}
+
+			internal.LogInfo("Deleted pod %s in namespace %s", pod.Name, k8Client.GetCurrentNamespace())
+		},
+	}
+
+	var datalossRecover = &cobra.Command{
+		Use:   "recover",
+		Short: "Recover broker after full data loss",
+		Long:  `Restart the broker after full data loss, wait until the data is fully recovered`,
+		Run: func(cmd *cobra.Command, args []string) {
+
+			k8Client, err := internal.CreateK8Client()
+			if err != nil {
+				panic(err)
+			}
+
+			err = internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "false")
+			if err != nil {
+				panic(err)
+			}
+
+			pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
+
+			if err != nil {
+				internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
+				panic(err)
+			}
+
+			// The pod is restarting after dataloss, so it takes longer to be ready
+			err = k8Client.AwaitPodReadiness(pod.Name, 10*time.Minute)
+
+			if err != nil {
+				internal.LogInfo("%s", err)
+				panic(err)
+			}
+			internal.LogInfo("Broker %d is recovered", flags.nodeId)
+		},
+	}
+
 	rootCmd.AddCommand(datalossCmd)
 	datalossCmd.AddCommand(prepareCmd)
 	datalossCmd.AddCommand(datalossDelete)
@@ -29,96 +122,4 @@ func init() {
 
 	datalossDelete.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
 	datalossRecover.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
-}
-
-var datalossCmd = &cobra.Command{
-	Use:   "dataloss",
-	Short: "Simulate dataloss and recover",
-	Long:  `Simulate dataloss of a broker, and recover from it.`,
-}
-
-var prepareCmd = &cobra.Command{
-	Use:   "prepare",
-	Short: "Prepare the k8s deployment for dataloss test",
-	Long:  `Prepares the k8s deployment - such as applying patches to statefulsets - to enable applying dataloss commands.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		// Add Init container for dataloss simulation test
-		err = k8Client.ApplyInitContainerPatch()
-
-		if err != nil {
-			panic(err)
-		}
-
-		internal.LogInfo("Prepared cluster in namesapce %s", k8Client.GetCurrentNamespace())
-	},
-}
-
-var datalossDelete = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete data of a broker",
-	Long:  `Delete data of a broker by deleting the pvc and the pod`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
-
-		if err != nil {
-			internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
-			panic(err)
-		}
-
-		k8Client.DeletePvcOfBroker(pod.Name)
-
-		internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "true")
-		err = k8Client.RestartPod(pod.Name)
-		if err != nil {
-			internal.LogInfo("Failed to restart pod %s", pod.Name)
-			panic(err)
-		}
-
-		internal.LogInfo("Deleted pod %s in namespace %s", pod.Name, k8Client.GetCurrentNamespace())
-	},
-}
-
-var datalossRecover = &cobra.Command{
-	Use:   "recover",
-	Short: "Recover broker after full data loss",
-	Long:  `Restart the broker after full data loss, wait until the data is fully recovered`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		err = internal.SetInitContainerBlockFlag(k8Client, flags.nodeId, "false")
-		if err != nil {
-			panic(err)
-		}
-
-		pod, err := internal.GetBrokerPodForNodeId(k8Client, int32(flags.nodeId))
-
-		if err != nil {
-			internal.LogInfo("Failed to get pod with nodeId %d %s", flags.nodeId, err)
-			panic(err)
-		}
-
-		// The pod is restarting after dataloss, so it takes longer to be ready
-		err = k8Client.AwaitPodReadiness(pod.Name, 10*time.Minute)
-
-		if err != nil {
-			internal.LogInfo("%s", err)
-			panic(err)
-		}
-		internal.LogInfo("Broker %d is recovered", flags.nodeId)
-	},
 }

--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -35,7 +35,7 @@ func AddDeployCmd(rootCmd *cobra.Command, flags Flags) {
 Can be used to deploy a specific process model or multiple version of a default BPMN and DMN model.
 Defaults to the later, which is useful for experimenting with deployment distribution.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			port := 26500
@@ -59,7 +59,7 @@ Defaults to the later, which is useful for experimenting with deployment distrib
 		Long: `Deploy multiple versions of process and dmn models to Zeebe.
 Useful for experimenting with deployment distribution.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			port := 26500
@@ -82,7 +82,7 @@ Useful for experimenting with deployment distribution.`,
 		Long: `Deploy a worker deployment to the Zeebe cluster. 
 The workers can be used as part of some chaos experiments to complete process instances etc.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			err = k8Client.CreateWorkerDeployment()
@@ -98,7 +98,7 @@ The workers can be used as part of some chaos experiments to complete process in
 		Long: `Deploy all chaos BPMN models to the to the Zeebe cluster. 
 The process models allow to execute chaos experiments.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			zbClient, closeFn, err := backend.ConnectToZeebeCluster(k8Client)

--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -24,11 +24,11 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.AddCommand(deployProcessModelCmd)
-	deployProcessModelCmd.Flags().StringVar(&processModelPath, "processModelPath", "",
+	deployProcessModelCmd.Flags().StringVar(&flags.processModelPath, "processModelPath", "",
 		"Specify the path to a BPMN process model, which should be deployed. Defaults to a benchmark process model with one task (included in zbchaos). If the path starts with 'bpmn/' zbchaos will look for a referenced model bundled within the cli, like: 'bpmn/one_task.bpmn'.")
 
 	deployCmd.AddCommand(deployMultiVersionProcessModelCmd)
-	deployMultiVersionProcessModelCmd.Flags().IntVar(&versionCount, "versionCount", 10,
+	deployMultiVersionProcessModelCmd.Flags().IntVar(&flags.versionCount, "versionCount", 10,
 		"Specify how many different versions of a default BPMN and DMN model should be deployed. Useful for testing deployment distribution.")
 
 	deployCmd.AddCommand(deployWorkerCmd)
@@ -59,10 +59,10 @@ Defaults to the later, which is useful for experimenting with deployment distrib
 		ensureNoError(err)
 		defer zbClient.Close()
 
-		processDefinitionKey, err := internal.DeployModel(zbClient, processModelPath)
+		processDefinitionKey, err := internal.DeployModel(zbClient, flags.processModelPath)
 		ensureNoError(err)
 
-		internal.LogInfo("Deployed given process model %s, under key %d!", processModelPath, processDefinitionKey)
+		internal.LogInfo("Deployed given process model %s, under key %d!", flags.processModelPath, processDefinitionKey)
 	},
 }
 
@@ -83,7 +83,7 @@ Useful for experimenting with deployment distribution.`,
 		ensureNoError(err)
 		defer zbClient.Close()
 
-		err = internal.DeployDifferentVersions(zbClient, int32(versionCount))
+		err = internal.DeployDifferentVersions(zbClient, int32(flags.versionCount))
 		ensureNoError(err)
 		internal.LogInfo("Deployed different process models of different types and versions to zeebe!")
 	},

--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -20,7 +20,98 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddDeployCmd(rootCmd *cobra.Command, flags Flags) {
+
+	var deployCmd = &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploy certain resource",
+		Long:  `Deploy certain resource, like process model(s) or kubernetes manifest.`,
+	}
+
+	var deployProcessModelCmd = &cobra.Command{
+		Use:   "process",
+		Short: "Deploy a process model to Zeebe",
+		Long: `Deploy a process model to Zeebe. 
+Can be used to deploy a specific process model or multiple version of a default BPMN and DMN model.
+Defaults to the later, which is useful for experimenting with deployment distribution.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			ensureNoError(err)
+
+			port := 26500
+			closeFn := k8Client.MustGatewayPortForward(port, port)
+			defer closeFn()
+
+			zbClient, err := internal.CreateZeebeClient(port)
+			ensureNoError(err)
+			defer zbClient.Close()
+
+			processDefinitionKey, err := internal.DeployModel(zbClient, flags.processModelPath)
+			ensureNoError(err)
+
+			internal.LogInfo("Deployed given process model %s, under key %d!", flags.processModelPath, processDefinitionKey)
+		},
+	}
+
+	var deployMultiVersionProcessModelCmd = &cobra.Command{
+		Use:   "multi-version",
+		Short: "Deploy multiple versions to Zeebe",
+		Long: `Deploy multiple versions of process and dmn models to Zeebe.
+Useful for experimenting with deployment distribution.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			ensureNoError(err)
+
+			port := 26500
+			closeFn := k8Client.MustGatewayPortForward(port, port)
+			defer closeFn()
+
+			zbClient, err := internal.CreateZeebeClient(port)
+			ensureNoError(err)
+			defer zbClient.Close()
+
+			err = internal.DeployDifferentVersions(zbClient, int32(flags.versionCount))
+			ensureNoError(err)
+			internal.LogInfo("Deployed different process models of different types and versions to zeebe!")
+		},
+	}
+
+	var deployWorkerCmd = &cobra.Command{
+		Use:   "worker",
+		Short: "Deploy a worker deployment to the Zeebe cluster",
+		Long: `Deploy a worker deployment to the Zeebe cluster. 
+The workers can be used as part of some chaos experiments to complete process instances etc.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			ensureNoError(err)
+
+			err = k8Client.CreateWorkerDeployment()
+			ensureNoError(err)
+
+			internal.LogInfo("Worker successfully deployed to the current namespace: %s", k8Client.GetCurrentNamespace())
+		},
+	}
+
+	var deployChaosModels = &cobra.Command{
+		Use:   "chaos",
+		Short: "Deploy all chaos BPMN models to the Zeebe cluster",
+		Long: `Deploy all chaos BPMN models to the to the Zeebe cluster. 
+The process models allow to execute chaos experiments.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			ensureNoError(err)
+
+			zbClient, closeFn, err := backend.ConnectToZeebeCluster(k8Client)
+			ensureNoError(err)
+			defer closeFn()
+
+			err = internal.DeployChaosModels(zbClient)
+			ensureNoError(err)
+
+			internal.LogInfo("Deployed successfully process models to run chaos experiments")
+		},
+	}
+
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.AddCommand(deployProcessModelCmd)
@@ -33,94 +124,4 @@ func init() {
 
 	deployCmd.AddCommand(deployWorkerCmd)
 	deployCmd.AddCommand(deployChaosModels)
-}
-
-var deployCmd = &cobra.Command{
-	Use:   "deploy",
-	Short: "Deploy certain resource",
-	Long:  `Deploy certain resource, like process model(s) or kubernetes manifest.`,
-}
-
-var deployProcessModelCmd = &cobra.Command{
-	Use:   "process",
-	Short: "Deploy a process model to Zeebe",
-	Long: `Deploy a process model to Zeebe. 
-Can be used to deploy a specific process model or multiple version of a default BPMN and DMN model.
-Defaults to the later, which is useful for experimenting with deployment distribution.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		ensureNoError(err)
-
-		port := 26500
-		closeFn := k8Client.MustGatewayPortForward(port, port)
-		defer closeFn()
-
-		zbClient, err := internal.CreateZeebeClient(port)
-		ensureNoError(err)
-		defer zbClient.Close()
-
-		processDefinitionKey, err := internal.DeployModel(zbClient, flags.processModelPath)
-		ensureNoError(err)
-
-		internal.LogInfo("Deployed given process model %s, under key %d!", flags.processModelPath, processDefinitionKey)
-	},
-}
-
-var deployMultiVersionProcessModelCmd = &cobra.Command{
-	Use:   "multi-version",
-	Short: "Deploy multiple versions to Zeebe",
-	Long: `Deploy multiple versions of process and dmn models to Zeebe.
-Useful for experimenting with deployment distribution.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		ensureNoError(err)
-
-		port := 26500
-		closeFn := k8Client.MustGatewayPortForward(port, port)
-		defer closeFn()
-
-		zbClient, err := internal.CreateZeebeClient(port)
-		ensureNoError(err)
-		defer zbClient.Close()
-
-		err = internal.DeployDifferentVersions(zbClient, int32(flags.versionCount))
-		ensureNoError(err)
-		internal.LogInfo("Deployed different process models of different types and versions to zeebe!")
-	},
-}
-
-var deployWorkerCmd = &cobra.Command{
-	Use:   "worker",
-	Short: "Deploy a worker deployment to the Zeebe cluster",
-	Long: `Deploy a worker deployment to the Zeebe cluster. 
-The workers can be used as part of some chaos experiments to complete process instances etc.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		ensureNoError(err)
-
-		err = k8Client.CreateWorkerDeployment()
-		ensureNoError(err)
-
-		internal.LogInfo("Worker successfully deployed to the current namespace: %s", k8Client.GetCurrentNamespace())
-	},
-}
-
-var deployChaosModels = &cobra.Command{
-	Use:   "chaos",
-	Short: "Deploy all chaos BPMN models to the Zeebe cluster",
-	Long: `Deploy all chaos BPMN models to the to the Zeebe cluster. 
-The process models allow to execute chaos experiments.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		ensureNoError(err)
-
-		zbClient, closeFn, err := backend.ConnectToZeebeCluster(k8Client)
-		ensureNoError(err)
-		defer closeFn()
-
-		err = internal.DeployChaosModels(zbClient)
-		ensureNoError(err)
-
-		internal.LogInfo("Deployed successfully process models to run chaos experiments")
-	},
 }

--- a/go-chaos/cmd/disconnect.go
+++ b/go-chaos/cmd/disconnect.go
@@ -38,7 +38,7 @@ func AddDisconnectCommand(rootCmd *cobra.Command, flags Flags) {
 		Short: "Disconnect Zeebe Brokers",
 		Long:  `Disconnect Zeebe Brokers with a given partition and role.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := backend.DisconnectBroker(backend.DisconnectBrokerCfg{
+			err := backend.DisconnectBroker(flags.kubeConfigPath, flags.namespace, backend.DisconnectBrokerCfg{
 				Broker1Cfg: backend.Broker{
 					NodeId:      flags.broker1NodeId,
 					PartitionId: flags.broker1PartitionId,
@@ -60,7 +60,7 @@ func AddDisconnectCommand(rootCmd *cobra.Command, flags Flags) {
 		Short: "Disconnect Zeebe Gateway",
 		Long:  `Disconnect Zeebe Gateway from Broker with a given partition and role.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := backend.DisconnectGateway(backend.DisconnectGatewayCfg{
+			err := backend.DisconnectGateway(flags.kubeConfigPath, flags.namespace, backend.DisconnectGatewayCfg{
 				OneDirection:    flags.oneDirection,
 				DisconnectToAll: flags.disconnectToAll,
 				BrokerCfg: backend.Broker{

--- a/go-chaos/cmd/disconnect.go
+++ b/go-chaos/cmd/disconnect.go
@@ -20,8 +20,6 @@ import (
 )
 
 var (
-	oneDirection    bool
-	disconnectToAll bool
 )
 
 func init() {
@@ -30,25 +28,25 @@ func init() {
 	// disconnect brokers
 	disconnect.AddCommand(disconnectBrokers)
 	// broker 1
-	disconnectBrokers.Flags().StringVar(&broker1Role, "broker1Role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the first Broker")
-	disconnectBrokers.Flags().IntVar(&broker1PartitionId, "broker1PartitionId", 1, "Specify the partition id of the first Broker")
-	disconnectBrokers.Flags().IntVar(&broker1NodeId, "broker1NodeId", -1, "Specify the nodeId of the first Broker")
+	disconnectBrokers.Flags().StringVar(&flags.broker1Role, "broker1Role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the first Broker")
+	disconnectBrokers.Flags().IntVar(&flags.broker1PartitionId, "broker1PartitionId", 1, "Specify the partition id of the first Broker")
+	disconnectBrokers.Flags().IntVar(&flags.broker1NodeId, "broker1NodeId", -1, "Specify the nodeId of the first Broker")
 	disconnectBrokers.MarkFlagsMutuallyExclusive("broker1PartitionId", "broker1NodeId")
 	// broker 2
-	disconnectBrokers.Flags().StringVar(&broker2Role, "broker2Role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the second Broker")
-	disconnectBrokers.Flags().IntVar(&broker2PartitionId, "broker2PartitionId", 2, "Specify the partition id of the second Broker")
-	disconnectBrokers.Flags().IntVar(&broker2NodeId, "broker2NodeId", -1, "Specify the nodeId of the second Broker")
+	disconnectBrokers.Flags().StringVar(&flags.broker2Role, "broker2Role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the second Broker")
+	disconnectBrokers.Flags().IntVar(&flags.broker2PartitionId, "broker2PartitionId", 2, "Specify the partition id of the second Broker")
+	disconnectBrokers.Flags().IntVar(&flags.broker2NodeId, "broker2NodeId", -1, "Specify the nodeId of the second Broker")
 	// general
-	disconnectBrokers.Flags().BoolVar(&oneDirection, "one-direction", false, "Specify whether the network partition should be setup only in one direction (asymmetric)")
+	disconnectBrokers.Flags().BoolVar(&flags.oneDirection, "one-direction", false, "Specify whether the network partition should be setup only in one direction (asymmetric)")
 	disconnectBrokers.MarkFlagsMutuallyExclusive("broker2PartitionId", "broker2NodeId")
 
 	// disconnect gateway
 	disconnect.AddCommand(disconnectGateway)
-	disconnectGateway.Flags().IntVar(&nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
-	disconnectGateway.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the Broker")
-	disconnectGateway.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the partition id of the Broker")
-	disconnectGateway.Flags().BoolVar(&oneDirection, "one-direction", false, "Specify whether the network partition should be setup only in one direction (asymmetric)")
-	disconnectGateway.Flags().BoolVar(&disconnectToAll, "all", false, "Specify whether the gateway should be disconnected to all brokers")
+	disconnectGateway.Flags().IntVar(&flags.nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
+	disconnectGateway.Flags().StringVar(&flags.role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER] of the Broker")
+	disconnectGateway.Flags().IntVar(&flags.partitionId, "partitionId", 1, "Specify the partition id of the Broker")
+	disconnectGateway.Flags().BoolVar(&flags.oneDirection, "one-direction", false, "Specify whether the network partition should be setup only in one direction (asymmetric)")
+	disconnectGateway.Flags().BoolVar(&flags.disconnectToAll, "all", false, "Specify whether the gateway should be disconnected to all brokers")
 	disconnectGateway.MarkFlagsMutuallyExclusive("all", "partitionId", "nodeId")
 }
 
@@ -71,16 +69,16 @@ var disconnectBrokers = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := backend.DisconnectBroker(backend.DisconnectBrokerCfg{
 			Broker1Cfg: backend.Broker{
-				NodeId:      broker1NodeId,
-				PartitionId: broker1PartitionId,
-				Role:        broker1Role,
+				NodeId:      flags.broker1NodeId,
+				PartitionId: flags.broker1PartitionId,
+				Role:        flags.broker1Role,
 			},
 			Broker2Cfg: backend.Broker{
-				NodeId:      broker2NodeId,
-				PartitionId: broker2PartitionId,
-				Role:        broker2Role,
+				NodeId:      flags.broker2NodeId,
+				PartitionId: flags.broker2PartitionId,
+				Role:        flags.broker2Role,
 			},
-			OneDirection: oneDirection,
+			OneDirection: flags.oneDirection,
 		})
 		ensureNoError(err)
 	},
@@ -92,12 +90,12 @@ var disconnectGateway = &cobra.Command{
 	Long:  `Disconnect Zeebe Gateway from Broker with a given partition and role.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := backend.DisconnectGateway(backend.DisconnectGatewayCfg{
-			OneDirection:    oneDirection,
-			DisconnectToAll: disconnectToAll,
+			OneDirection:    flags.oneDirection,
+			DisconnectToAll: flags.disconnectToAll,
 			BrokerCfg: backend.Broker{
-				Role:        role,
-				PartitionId: partitionId,
-				NodeId:      nodeId,
+				Role:        flags.role,
+				PartitionId: flags.partitionId,
+				NodeId:      flags.nodeId,
 			},
 		})
 		ensureNoError(err)

--- a/go-chaos/cmd/disconnect.go
+++ b/go-chaos/cmd/disconnect.go
@@ -19,10 +19,60 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/backend"
 )
 
-var (
-)
+func ensureNoError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
 
-func init() {
+func AddDisconnectCommand(rootCmd *cobra.Command, flags Flags) {
+
+	var disconnect = &cobra.Command{
+		Use:   "disconnect",
+		Short: "Disconnect Zeebe nodes",
+		Long:  `Disconnect Zeebe nodes, uses sub-commands to disconnect leaders, followers, etc.`,
+	}
+
+	var disconnectBrokers = &cobra.Command{
+		Use:   "brokers",
+		Short: "Disconnect Zeebe Brokers",
+		Long:  `Disconnect Zeebe Brokers with a given partition and role.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := backend.DisconnectBroker(backend.DisconnectBrokerCfg{
+				Broker1Cfg: backend.Broker{
+					NodeId:      flags.broker1NodeId,
+					PartitionId: flags.broker1PartitionId,
+					Role:        flags.broker1Role,
+				},
+				Broker2Cfg: backend.Broker{
+					NodeId:      flags.broker2NodeId,
+					PartitionId: flags.broker2PartitionId,
+					Role:        flags.broker2Role,
+				},
+				OneDirection: flags.oneDirection,
+			})
+			ensureNoError(err)
+		},
+	}
+
+	var disconnectGateway = &cobra.Command{
+		Use:   "gateway",
+		Short: "Disconnect Zeebe Gateway",
+		Long:  `Disconnect Zeebe Gateway from Broker with a given partition and role.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := backend.DisconnectGateway(backend.DisconnectGatewayCfg{
+				OneDirection:    flags.oneDirection,
+				DisconnectToAll: flags.disconnectToAll,
+				BrokerCfg: backend.Broker{
+					Role:        flags.role,
+					PartitionId: flags.partitionId,
+					NodeId:      flags.nodeId,
+				},
+			})
+			ensureNoError(err)
+		},
+	}
+
 	rootCmd.AddCommand(disconnect)
 
 	// disconnect brokers
@@ -48,56 +98,4 @@ func init() {
 	disconnectGateway.Flags().BoolVar(&flags.oneDirection, "one-direction", false, "Specify whether the network partition should be setup only in one direction (asymmetric)")
 	disconnectGateway.Flags().BoolVar(&flags.disconnectToAll, "all", false, "Specify whether the gateway should be disconnected to all brokers")
 	disconnectGateway.MarkFlagsMutuallyExclusive("all", "partitionId", "nodeId")
-}
-
-var disconnect = &cobra.Command{
-	Use:   "disconnect",
-	Short: "Disconnect Zeebe nodes",
-	Long:  `Disconnect Zeebe nodes, uses sub-commands to disconnect leaders, followers, etc.`,
-}
-
-func ensureNoError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
-var disconnectBrokers = &cobra.Command{
-	Use:   "brokers",
-	Short: "Disconnect Zeebe Brokers",
-	Long:  `Disconnect Zeebe Brokers with a given partition and role.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := backend.DisconnectBroker(backend.DisconnectBrokerCfg{
-			Broker1Cfg: backend.Broker{
-				NodeId:      flags.broker1NodeId,
-				PartitionId: flags.broker1PartitionId,
-				Role:        flags.broker1Role,
-			},
-			Broker2Cfg: backend.Broker{
-				NodeId:      flags.broker2NodeId,
-				PartitionId: flags.broker2PartitionId,
-				Role:        flags.broker2Role,
-			},
-			OneDirection: flags.oneDirection,
-		})
-		ensureNoError(err)
-	},
-}
-
-var disconnectGateway = &cobra.Command{
-	Use:   "gateway",
-	Short: "Disconnect Zeebe Gateway",
-	Long:  `Disconnect Zeebe Gateway from Broker with a given partition and role.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := backend.DisconnectGateway(backend.DisconnectGatewayCfg{
-			OneDirection:    flags.oneDirection,
-			DisconnectToAll: flags.disconnectToAll,
-			BrokerCfg: backend.Broker{
-				Role:        flags.role,
-				PartitionId: flags.partitionId,
-				NodeId:      flags.nodeId,
-			},
-		})
-		ensureNoError(err)
-	},
 }

--- a/go-chaos/cmd/exporting.go
+++ b/go-chaos/cmd/exporting.go
@@ -22,7 +22,7 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func AddExportingCmds(rootCmd *cobra.Command) {
+func AddExportingCmds(rootCmd *cobra.Command, flags Flags) {
 	var exportingCommand = &cobra.Command{
 		Use:   "exporting",
 		Short: "Controls Zeebe Exporting",
@@ -32,13 +32,21 @@ func AddExportingCmds(rootCmd *cobra.Command) {
 	var pauseExportingCommand = &cobra.Command{
 		Use:   "pause",
 		Short: "Pause exporting on all partitions",
-		RunE:  pauseExporting,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8Client, err := createK8ClientWithFlags(flags)
+			ensureNoError(err)
+			return pauseExporting(k8Client)
+		},
 	}
 
 	var resumeExportingCommand = &cobra.Command{
 		Use:   "resume",
 		Short: "Resume exporting on all partitions",
-		RunE:  resumeExporting,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8Client, err := createK8ClientWithFlags(flags)
+			ensureNoError(err)
+			return resumeExporting(k8Client)
+		},
 	}
 
 	rootCmd.AddCommand(exportingCommand)
@@ -47,12 +55,7 @@ func AddExportingCmds(rootCmd *cobra.Command) {
 	exportingCommand.AddCommand(resumeExportingCommand)
 }
 
-func pauseExporting(cmd *cobra.Command, args []string) error {
-	k8Client, err := internal.CreateK8Client()
-	if err != nil {
-		panic(err)
-	}
-
+func pauseExporting(k8Client internal.K8Client) error {
 	port := 9600
 	closePortForward := k8Client.MustGatewayPortForward(port, port)
 	defer closePortForward()
@@ -65,12 +68,7 @@ func pauseExporting(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func resumeExporting(cmd *cobra.Command, args []string) error {
-	k8Client, err := internal.CreateK8Client()
-	if err != nil {
-		panic(err)
-	}
-
+func resumeExporting(k8Client internal.K8Client) error {
 	port := 9600
 	closePortForward := k8Client.MustGatewayPortForward(port, port)
 	defer closePortForward()
@@ -81,5 +79,4 @@ func resumeExporting(cmd *cobra.Command, args []string) error {
 	}
 	defer resp.Body.Close()
 	return err
-
 }

--- a/go-chaos/cmd/exporting.go
+++ b/go-chaos/cmd/exporting.go
@@ -22,29 +22,29 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddExportingCmds(rootCmd *cobra.Command) {
+	var exportingCommand = &cobra.Command{
+		Use:   "exporting",
+		Short: "Controls Zeebe Exporting",
+		Long:  "Can be used to start and stop exporting",
+	}
+
+	var pauseExportingCommand = &cobra.Command{
+		Use:   "pause",
+		Short: "Pause exporting on all partitions",
+		RunE:  pauseExporting,
+	}
+
+	var resumeExportingCommand = &cobra.Command{
+		Use:   "resume",
+		Short: "Resume exporting on all partitions",
+		RunE:  resumeExporting,
+	}
+
 	rootCmd.AddCommand(exportingCommand)
 
 	exportingCommand.AddCommand(pauseExportingCommand)
 	exportingCommand.AddCommand(resumeExportingCommand)
-}
-
-var exportingCommand = &cobra.Command{
-	Use:   "exporting",
-	Short: "Controls Zeebe Exporting",
-	Long:  "Can be used to start and stop exporting",
-}
-
-var pauseExportingCommand = &cobra.Command{
-	Use:   "pause",
-	Short: "Pause exporting on all partitions",
-	RunE:  pauseExporting,
-}
-
-var resumeExportingCommand = &cobra.Command{
-	Use:   "resume",
-	Short: "Resume exporting on all partitions",
-	RunE:  resumeExporting,
 }
 
 func pauseExporting(cmd *cobra.Command, args []string) error {

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -29,7 +29,7 @@ func AddPublishCmd(rootCmd *cobra.Command, flags Flags) {
 		Short: "Publish a message",
 		Long:  `Publish a message to a certain partition.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			panicOnError(err)
 
 			port := 26500

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -24,8 +24,8 @@ import (
 
 func init() {
 	rootCmd.AddCommand(publishCmd)
-	publishCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
-	publishCmd.Flags().StringVar(&msgName, "msgName", "msg", "Specify the name of the message, which should be published.")
+	publishCmd.Flags().IntVar(&flags.partitionId, "partitionId", 1, "Specify the id of the partition")
+	publishCmd.Flags().StringVar(&flags.msgName, "msgName", "msg", "Specify the name of the message, which should be published.")
 }
 
 var publishCmd = &cobra.Command{
@@ -47,12 +47,12 @@ var publishCmd = &cobra.Command{
 		topology, err := internal.GetTopology(zbClient)
 		panicOnError(err)
 
-		correlationKey, err := internal.FindCorrelationKeyForPartition(partitionId, int(topology.PartitionsCount))
+		correlationKey, err := internal.FindCorrelationKeyForPartition(flags.partitionId, int(topology.PartitionsCount))
 		panicOnError(err)
 
-		internal.LogVerbose("Send message '%s', with correaltion key '%s' (ASCII: %d) ", msgName, correlationKey, int(correlationKey[0]))
+		internal.LogVerbose("Send message '%s', with correaltion key '%s' (ASCII: %d) ", flags.msgName, correlationKey, int(correlationKey[0]))
 
-		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
+		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(flags.msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
 		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
 
 		internal.LogInfo("Message was sent and returned key %d, which corresponds to partition: %d", messageResponse.Key, partitionIdFromKey)

--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -22,41 +22,42 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddPublishCmd(rootCmd *cobra.Command, flags Flags) {
+
+	var publishCmd = &cobra.Command{
+		Use:   "publish",
+		Short: "Publish a message",
+		Long:  `Publish a message to a certain partition.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			panicOnError(err)
+
+			port := 26500
+			closeFn := k8Client.MustGatewayPortForward(port, port)
+			defer closeFn()
+
+			zbClient, err := internal.CreateZeebeClient(port)
+			panicOnError(err)
+			defer zbClient.Close()
+
+			topology, err := internal.GetTopology(zbClient)
+			panicOnError(err)
+
+			correlationKey, err := internal.FindCorrelationKeyForPartition(flags.partitionId, int(topology.PartitionsCount))
+			panicOnError(err)
+
+			internal.LogVerbose("Send message '%s', with correaltion key '%s' (ASCII: %d) ", flags.msgName, correlationKey, int(correlationKey[0]))
+
+			messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(flags.msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
+			partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
+
+			internal.LogInfo("Message was sent and returned key %d, which corresponds to partition: %d", messageResponse.Key, partitionIdFromKey)
+		},
+	}
+
 	rootCmd.AddCommand(publishCmd)
 	publishCmd.Flags().IntVar(&flags.partitionId, "partitionId", 1, "Specify the id of the partition")
 	publishCmd.Flags().StringVar(&flags.msgName, "msgName", "msg", "Specify the name of the message, which should be published.")
-}
-
-var publishCmd = &cobra.Command{
-	Use:   "publish",
-	Short: "Publish a message",
-	Long:  `Publish a message to a certain partition.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		panicOnError(err)
-
-		port := 26500
-		closeFn := k8Client.MustGatewayPortForward(port, port)
-		defer closeFn()
-
-		zbClient, err := internal.CreateZeebeClient(port)
-		panicOnError(err)
-		defer zbClient.Close()
-
-		topology, err := internal.GetTopology(zbClient)
-		panicOnError(err)
-
-		correlationKey, err := internal.FindCorrelationKeyForPartition(flags.partitionId, int(topology.PartitionsCount))
-		panicOnError(err)
-
-		internal.LogVerbose("Send message '%s', with correaltion key '%s' (ASCII: %d) ", flags.msgName, correlationKey, int(correlationKey[0]))
-
-		messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(flags.msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
-		partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
-
-		internal.LogInfo("Message was sent and returned key %d, which corresponds to partition: %d", messageResponse.Key, partitionIdFromKey)
-	},
 }
 
 func panicOnError(err error) {

--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -22,14 +22,14 @@ import (
 func init() {
 	rootCmd.AddCommand(restartCmd)
 	restartCmd.AddCommand(restartBrokerCmd)
-	restartBrokerCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER, INACTIVE]")
-	restartBrokerCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
-	restartBrokerCmd.Flags().IntVar(&nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
+	restartBrokerCmd.Flags().StringVar(&flags.role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER, INACTIVE]")
+	restartBrokerCmd.Flags().IntVar(&flags.partitionId, "partitionId", 1, "Specify the id of the partition")
+	restartBrokerCmd.Flags().IntVar(&flags.nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
 	restartBrokerCmd.MarkFlagsMutuallyExclusive("partitionId", "nodeId")
 
 	restartCmd.AddCommand(restartGatewayCmd)
 	restartCmd.AddCommand(restartWorkerCmd)
-	restartWorkerCmd.Flags().BoolVar(&all, "all", false, "Specify whether all workers should be restarted")
+	restartWorkerCmd.Flags().BoolVar(&flags.all, "all", false, "Specify whether all workers should be restarted")
 }
 
 var restartCmd = &cobra.Command{
@@ -43,7 +43,7 @@ var restartBrokerCmd = &cobra.Command{
 	Short: "Restarts a Zeebe broker",
 	Long:  `Restarts a Zeebe broker with a certain role and given partition.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		brokerPod := restartBroker(nodeId, partitionId, role, nil)
+		brokerPod := restartBroker(flags.nodeId, flags.partitionId, flags.role, nil)
 		internal.LogInfo("Restarted %s", brokerPod)
 	},
 }
@@ -63,6 +63,6 @@ var restartWorkerCmd = &cobra.Command{
 	Short: "Restart a Zeebe worker",
 	Long:  `Restart a Zeebe worker.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		restartWorker(all, "Restarted", nil)
+		restartWorker(flags.all, "Restarted", nil)
 	},
 }

--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -19,7 +19,43 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddRestartCmd(rootCmd *cobra.Command, flags Flags) {
+
+	var restartCmd = &cobra.Command{
+		Use:   "restart",
+		Short: "Restarts a Zeebe node",
+		Long:  `Restarts a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
+	}
+
+	var restartBrokerCmd = &cobra.Command{
+		Use:   "broker",
+		Short: "Restarts a Zeebe broker",
+		Long:  `Restarts a Zeebe broker with a certain role and given partition.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			brokerPod := restartBroker(flags.nodeId, flags.partitionId, flags.role, nil)
+			internal.LogInfo("Restarted %s", brokerPod)
+		},
+	}
+
+	var restartGatewayCmd = &cobra.Command{
+		Use:   "gateway",
+		Short: "Restarts a Zeebe gateway",
+		Long:  `Restarts a Zeebe gateway.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			gatewayPod := restartGateway(nil)
+			internal.LogInfo("Restarted %s", gatewayPod)
+		},
+	}
+
+	var restartWorkerCmd = &cobra.Command{
+		Use:   "worker",
+		Short: "Restart a Zeebe worker",
+		Long:  `Restart a Zeebe worker.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			restartWorker(flags.all, "Restarted", nil)
+		},
+	}
+
 	rootCmd.AddCommand(restartCmd)
 	restartCmd.AddCommand(restartBrokerCmd)
 	restartBrokerCmd.Flags().StringVar(&flags.role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER, INACTIVE]")
@@ -30,39 +66,4 @@ func init() {
 	restartCmd.AddCommand(restartGatewayCmd)
 	restartCmd.AddCommand(restartWorkerCmd)
 	restartWorkerCmd.Flags().BoolVar(&flags.all, "all", false, "Specify whether all workers should be restarted")
-}
-
-var restartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restarts a Zeebe node",
-	Long:  `Restarts a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
-}
-
-var restartBrokerCmd = &cobra.Command{
-	Use:   "broker",
-	Short: "Restarts a Zeebe broker",
-	Long:  `Restarts a Zeebe broker with a certain role and given partition.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		brokerPod := restartBroker(flags.nodeId, flags.partitionId, flags.role, nil)
-		internal.LogInfo("Restarted %s", brokerPod)
-	},
-}
-
-var restartGatewayCmd = &cobra.Command{
-	Use:   "gateway",
-	Short: "Restarts a Zeebe gateway",
-	Long:  `Restarts a Zeebe gateway.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gatewayPod := restartGateway(nil)
-		internal.LogInfo("Restarted %s", gatewayPod)
-	},
-}
-
-var restartWorkerCmd = &cobra.Command{
-	Use:   "worker",
-	Short: "Restart a Zeebe worker",
-	Long:  `Restart a Zeebe worker.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		restartWorker(flags.all, "Restarted", nil)
-	},
 }

--- a/go-chaos/cmd/restart.go
+++ b/go-chaos/cmd/restart.go
@@ -32,7 +32,9 @@ func AddRestartCmd(rootCmd *cobra.Command, flags Flags) {
 		Short: "Restarts a Zeebe broker",
 		Long:  `Restarts a Zeebe broker with a certain role and given partition.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			brokerPod := restartBroker(flags.nodeId, flags.partitionId, flags.role, nil)
+			k8Client, err := createK8ClientWithFlags(flags)
+			ensureNoError(err)
+			brokerPod := restartBroker(k8Client, flags.nodeId, flags.partitionId, flags.role, nil)
 			internal.LogInfo("Restarted %s", brokerPod)
 		},
 	}
@@ -42,7 +44,9 @@ func AddRestartCmd(rootCmd *cobra.Command, flags Flags) {
 		Short: "Restarts a Zeebe gateway",
 		Long:  `Restarts a Zeebe gateway.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			gatewayPod := restartGateway(nil)
+			k8Client, err := createK8ClientWithFlags(flags)
+			ensureNoError(err)
+			gatewayPod := restartGateway(k8Client, nil)
 			internal.LogInfo("Restarted %s", gatewayPod)
 		},
 	}
@@ -52,7 +56,9 @@ func AddRestartCmd(rootCmd *cobra.Command, flags Flags) {
 		Short: "Restart a Zeebe worker",
 		Long:  `Restart a Zeebe worker.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			restartWorker(flags.all, "Restarted", nil)
+			k8Client, err := createK8ClientWithFlags(flags)
+			ensureNoError(err)
+			restartWorker(k8Client, flags.all, "Restarted", nil)
 		},
 	}
 

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -25,7 +25,7 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-var (
+type Flags struct {
 	partitionId        int
 	role               string
 	nodeId             int
@@ -40,8 +40,63 @@ var (
 	broker2PartitionId int
 	broker2Role        string
 	broker2NodeId      int
-)
 
+	// backup
+	backupId string
+
+	// disconnect
+	oneDirection    bool
+	disconnectToAll bool
+
+	// stress
+
+	cpuStress    bool
+	memoryStress bool
+	ioStress     bool
+	timeoutSec   string
+
+	// terminate
+
+	all bool
+
+	// verify
+	version       int
+	bpmnProcessId string
+	timeoutInSec  int
+}
+
+func (f *Flags) reset() {
+	f.partitionId = 0
+	f.role = ""
+	f.nodeId = 0
+	f.processModelPath = ""
+	f.versionCount = 0
+	f.variables = ""
+	f.msgName = ""
+	f.awaitResult = false
+	f.broker1PartitionId = 0
+	f.broker1Role = ""
+	f.broker1NodeId = 0
+	f.broker2PartitionId = 0
+	f.broker2Role = ""
+	f.broker2NodeId = 0
+	f.backupId = ""
+	f.oneDirection = false
+	f.disconnectToAll = false
+	f.cpuStress = false
+	f.memoryStress = false
+	f.ioStress = false
+	f.timeoutSec = ""
+	f.all = false
+	f.version = 0
+	f.bpmnProcessId = ""
+	f.timeoutInSec = 0
+}
+
+var flags = Flags{}
+
+var Version = "development"
+var Commit  = "HEAD"
 var Verbose bool
 var KubeConfigPath string
 var Namespace string

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/cobra"
@@ -70,9 +69,6 @@ var Commit = "HEAD"
 var Verbose bool
 var KubeConfigPath string
 var Namespace string
-var ClientId string
-var ClientSecret string
-var Audience string
 var JsonLogging bool
 
 func NewCmd() *cobra.Command {
@@ -91,13 +87,6 @@ func NewCmd() *cobra.Command {
 			}
 			internal.Namespace = Namespace
 			internal.KubeConfigPath = KubeConfigPath
-			if ClientId != "" && ClientSecret != "" {
-				internal.ZeebeClientCredential, _ = zbc.NewOAuthCredentialsProvider(&zbc.OAuthProviderConfig{
-					ClientID:     ClientId,
-					ClientSecret: ClientSecret,
-					Audience:     Audience,
-				})
-			}
 		},
 	}
 
@@ -105,9 +94,6 @@ func NewCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
 	rootCmd.PersistentFlags().StringVar(&KubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "connect to the given namespace")
-	rootCmd.PersistentFlags().StringVarP(&ClientId, "clientId", "c", "", "connect using the given clientId")
-	rootCmd.PersistentFlags().StringVar(&ClientSecret, "clientSecret", "", "connect using the given client secret")
-	rootCmd.PersistentFlags().StringVar(&Audience, "audience", "", "connect using the given client secret")
 
 	AddBackupCommand(rootCmd, flags)
 	AddBrokersCommand(rootCmd)

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -59,16 +59,16 @@ type Flags struct {
 	all bool
 
 	// verify
-	version       int
-	bpmnProcessId string
-	timeoutInSec  int
+	version        int
+	bpmnProcessId  string
+	timeoutInSec   int
+	kubeConfigPath string
+	namespace      string
 }
 
 var Version = "development"
 var Commit = "HEAD"
 var Verbose bool
-var KubeConfigPath string
-var Namespace string
 var JsonLogging bool
 
 func NewCmd() *cobra.Command {
@@ -85,33 +85,35 @@ func NewCmd() *cobra.Command {
 			if JsonLogging {
 				internal.JsonLogger = log.With().Logger()
 			}
-			internal.Namespace = Namespace
-			internal.KubeConfigPath = KubeConfigPath
 		},
 	}
 
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
-	rootCmd.PersistentFlags().StringVar(&KubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
-	rootCmd.PersistentFlags().StringVarP(&Namespace, "namespace", "n", "", "connect to the given namespace")
+	rootCmd.PersistentFlags().StringVar(&flags.kubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
+	rootCmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "", "connect to the given namespace")
 
 	AddBackupCommand(rootCmd, flags)
-	AddBrokersCommand(rootCmd)
-	AddConnectCmd(rootCmd)
+	AddBrokersCommand(rootCmd, flags)
+	AddConnectCmd(rootCmd, flags)
 	AddDatalossSimulationCmd(rootCmd, flags)
 	AddDeployCmd(rootCmd, flags)
 	AddDisconnectCommand(rootCmd, flags)
-	AddExportingCmds(rootCmd)
+	AddExportingCmds(rootCmd, flags)
 	AddPublishCmd(rootCmd, flags)
 	AddRestartCmd(rootCmd, flags)
 	AddStressCmd(rootCmd, flags)
 	AddTerminateCommand(rootCmd, flags)
-	AddTopologyCmd(rootCmd)
+	AddTopologyCmd(rootCmd, flags)
 	AddVerifyCommands(rootCmd, flags)
 	AddVersionCmd(rootCmd)
 	AddWorkerCmd(rootCmd)
 
 	return rootCmd
+}
+
+func createK8ClientWithFlags(flags Flags) (internal.K8Client, error) {
+	return internal.CreateK8Client(flags.kubeConfigPath, flags.namespace)
 }
 
 func Execute() {

--- a/go-chaos/cmd/stress.go
+++ b/go-chaos/cmd/stress.go
@@ -37,7 +37,7 @@ func AddStressCmd(rootCmd *cobra.Command, flags Flags) {
 		Long:  `Put stress on a Zeebe Broker. Broker can be identified via ID or partition and role. Stress can be of different kinds: memory, io or CPU.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			internal.Verbosity = Verbose
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			port := 26500
@@ -63,7 +63,7 @@ func AddStressCmd(rootCmd *cobra.Command, flags Flags) {
 		Long:  `Put stress on a Zeebe Gateway. Stress can be of different kinds: memory, io or CPU.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			internal.Verbosity = Verbose
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			pod := getGatewayPod(k8Client)

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -22,8 +22,46 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
+func AddTerminateCommand(rootCmd *cobra.Command, flags Flags) {
 
-func init() {
+	var terminateCmd = &cobra.Command{
+		Use:   "terminate",
+		Short: "Terminates a Zeebe node",
+		Long:  `Terminates a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
+	}
+
+	var terminateBrokerCmd = &cobra.Command{
+		Use:   "broker",
+		Short: "Terminates a Zeebe broker",
+		Long:  `Terminates a Zeebe broker with a certain role and given partition.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			gracePeriodSec := int64(0)
+			brokerName := restartBroker(flags.nodeId, flags.partitionId, flags.role, &gracePeriodSec)
+			internal.LogInfo("Terminated %s", brokerName)
+		},
+	}
+
+	var terminateGatewayCmd = &cobra.Command{
+		Use:   "gateway",
+		Short: "Terminates a Zeebe gateway",
+		Long:  `Terminates a Zeebe gateway.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			gracePeriodSec := int64(0)
+			gatewayPod := restartGateway(&gracePeriodSec)
+			internal.LogInfo("Terminated %s", gatewayPod)
+		},
+	}
+
+	var terminateWorkerCmd = &cobra.Command{
+		Use:   "worker",
+		Short: "Terminates a Zeebe worker",
+		Long:  `Terminates a Zeebe worker.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			gracePeriodSec := int64(0)
+			restartWorker(flags.all, "Terminated", &gracePeriodSec)
+		},
+	}
+
 	rootCmd.AddCommand(terminateCmd)
 
 	terminateCmd.AddCommand(terminateBrokerCmd)
@@ -36,44 +74,7 @@ func init() {
 
 	terminateCmd.AddCommand(terminateWorkerCmd)
 	terminateWorkerCmd.Flags().BoolVar(&flags.all, "all", false, "Specify whether all workers should be terminated")
-}
 
-var terminateCmd = &cobra.Command{
-	Use:   "terminate",
-	Short: "Terminates a Zeebe node",
-	Long:  `Terminates a Zeebe node, it can be chosen between: broker, gateway or a worker.`,
-}
-
-var terminateBrokerCmd = &cobra.Command{
-	Use:   "broker",
-	Short: "Terminates a Zeebe broker",
-	Long:  `Terminates a Zeebe broker with a certain role and given partition.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gracePeriodSec := int64(0)
-		brokerName := restartBroker(flags.nodeId, flags.partitionId, flags.role, &gracePeriodSec)
-		internal.LogInfo("Terminated %s", brokerName)
-	},
-}
-
-var terminateGatewayCmd = &cobra.Command{
-	Use:   "gateway",
-	Short: "Terminates a Zeebe gateway",
-	Long:  `Terminates a Zeebe gateway.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gracePeriodSec := int64(0)
-		gatewayPod := restartGateway(&gracePeriodSec)
-		internal.LogInfo("Terminated %s", gatewayPod)
-	},
-}
-
-var terminateWorkerCmd = &cobra.Command{
-	Use:   "worker",
-	Short: "Terminates a Zeebe worker",
-	Long:  `Terminates a Zeebe worker.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		gracePeriodSec := int64(0)
-		restartWorker(flags.all, "Terminated", &gracePeriodSec)
-	},
 }
 
 // Restart a broker pod. Pod is identified either by nodeId or by partitionId and role.

--- a/go-chaos/cmd/terminate.go
+++ b/go-chaos/cmd/terminate.go
@@ -22,23 +22,20 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-var (
-	all bool
-)
 
 func init() {
 	rootCmd.AddCommand(terminateCmd)
 
 	terminateCmd.AddCommand(terminateBrokerCmd)
-	terminateBrokerCmd.Flags().StringVar(&role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER]")
-	terminateBrokerCmd.Flags().IntVar(&partitionId, "partitionId", 1, "Specify the id of the partition")
-	terminateBrokerCmd.Flags().IntVar(&nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
+	terminateBrokerCmd.Flags().StringVar(&flags.role, "role", "LEADER", "Specify the partition role [LEADER, FOLLOWER]")
+	terminateBrokerCmd.Flags().IntVar(&flags.partitionId, "partitionId", 1, "Specify the id of the partition")
+	terminateBrokerCmd.Flags().IntVar(&flags.nodeId, "nodeId", -1, "Specify the nodeId of the Broker")
 	terminateBrokerCmd.MarkFlagsMutuallyExclusive("partitionId", "nodeId")
 
 	terminateCmd.AddCommand(terminateGatewayCmd)
 
 	terminateCmd.AddCommand(terminateWorkerCmd)
-	terminateWorkerCmd.Flags().BoolVar(&all, "all", false, "Specify whether all workers should be terminated")
+	terminateWorkerCmd.Flags().BoolVar(&flags.all, "all", false, "Specify whether all workers should be terminated")
 }
 
 var terminateCmd = &cobra.Command{
@@ -53,7 +50,7 @@ var terminateBrokerCmd = &cobra.Command{
 	Long:  `Terminates a Zeebe broker with a certain role and given partition.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		gracePeriodSec := int64(0)
-		brokerName := restartBroker(nodeId, partitionId, role, &gracePeriodSec)
+		brokerName := restartBroker(flags.nodeId, flags.partitionId, flags.role, &gracePeriodSec)
 		internal.LogInfo("Terminated %s", brokerName)
 	},
 }
@@ -75,7 +72,7 @@ var terminateWorkerCmd = &cobra.Command{
 	Long:  `Terminates a Zeebe worker.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		gracePeriodSec := int64(0)
-		restartWorker(all, "Terminated", &gracePeriodSec)
+		restartWorker(flags.all, "Terminated", &gracePeriodSec)
 	},
 }
 

--- a/go-chaos/cmd/topology.go
+++ b/go-chaos/cmd/topology.go
@@ -26,38 +26,38 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddTopologyCmd(rootCmd *cobra.Command) {
+
+	var topologyCmd = &cobra.Command{
+		Use:   "topology",
+		Short: "Print the Zeebe topology deployed in the current namespace",
+		Long:  `Shows the current Zeebe topology, in the current kubernetes namespace.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			if err != nil {
+				panic(err)
+			}
+
+			port := 26500
+			closeFn := k8Client.MustGatewayPortForward(port, port)
+			defer closeFn()
+
+			client, err := internal.CreateZeebeClient(port)
+			if err != nil {
+				panic(err)
+			}
+
+			response, err := client.NewTopologyCommand().Send(context.TODO())
+			if err != nil {
+				panic(err)
+			}
+
+			builder := strings.Builder{}
+			writeTopologyToOutput(&builder, response)
+			internal.LogInfo(builder.String())
+		},
+	}
 	rootCmd.AddCommand(topologyCmd)
-}
-
-var topologyCmd = &cobra.Command{
-	Use:   "topology",
-	Short: "Print the Zeebe topology deployed in the current namespace",
-	Long:  `Shows the current Zeebe topology, in the current kubernetes namespace.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		port := 26500
-		closeFn := k8Client.MustGatewayPortForward(port, port)
-		defer closeFn()
-
-		client, err := internal.CreateZeebeClient(port)
-		if err != nil {
-			panic(err)
-		}
-
-		response, err := client.NewTopologyCommand().Send(context.TODO())
-		if err != nil {
-			panic(err)
-		}
-
-		builder := strings.Builder{}
-		writeTopologyToOutput(&builder, response)
-		internal.LogInfo(builder.String())
-	},
 }
 
 func writeTopologyToOutput(output io.Writer, response *pb.TopologyResponse) {

--- a/go-chaos/cmd/topology.go
+++ b/go-chaos/cmd/topology.go
@@ -26,14 +26,14 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func AddTopologyCmd(rootCmd *cobra.Command) {
+func AddTopologyCmd(rootCmd *cobra.Command, flags Flags) {
 
 	var topologyCmd = &cobra.Command{
 		Use:   "topology",
 		Short: "Print the Zeebe topology deployed in the current namespace",
 		Long:  `Shows the current Zeebe topology, in the current kubernetes namespace.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			if err != nil {
 				panic(err)
 			}

--- a/go-chaos/cmd/verify.go
+++ b/go-chaos/cmd/verify.go
@@ -35,7 +35,7 @@ func AddVerifyCommands(rootCmd *cobra.Command, flags Flags) {
 		Long:  `Verifies the readiness of Zeebe nodes.`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			err = k8Client.AwaitReadiness()
@@ -51,7 +51,7 @@ func AddVerifyCommands(rootCmd *cobra.Command, flags Flags) {
 		Long: `Verifies that an instance from a specific process model can be created on a specific partition.
 Process instances are created until the required partition is reached.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
 			port := 26500

--- a/go-chaos/cmd/version.go
+++ b/go-chaos/cmd/version.go
@@ -22,21 +22,21 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-
 func VersionString() string {
 	commit := Commit[0:int(math.Min(8, float64(len(Commit))))]
 	return fmt.Sprintf("zbchaos %s (commit: %s)", Version, commit)
 }
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version of zbchaos",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		internal.LogInfo(VersionString())
-	},
-}
+func AddVersionCmd(rootCmd *cobra.Command) {
 
-func init() {
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of zbchaos",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			internal.LogInfo(VersionString())
+		},
+	}
+
 	rootCmd.AddCommand(versionCmd)
 }

--- a/go-chaos/cmd/version.go
+++ b/go-chaos/cmd/version.go
@@ -22,10 +22,6 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-var (
-	Version = "development"
-	Commit  = "HEAD"
-)
 
 func VersionString() string {
 	commit := Commit[0:int(math.Min(8, float64(len(Commit))))]

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -94,6 +94,7 @@ func handleZbChaosJob(client zbworker.JobClient, job entities.Job) {
 
 func runZbChaosCommand(args []string, ctx context.Context) error {
 	internal.LogInfo("Running command with args: %v ", args)
+	flags.reset()
 	rootCmd.SetArgs(args)
 	_, err := rootCmd.ExecuteContextC(ctx)
 	if err != nil {

--- a/go-chaos/cmd/worker.go
+++ b/go-chaos/cmd/worker.go
@@ -36,15 +36,14 @@ const ENV_CLIENT_ID = "CHAOS_AUTOMATION_CLUSTER_CLIENT_ID"
 const ENV_CLIENT_SECRET = "CHAOS_AUTOMATION_CLUSTER_CLIENT_SECRET"
 const ENV_ADDRESS = "CHAOS_AUTOMATION_CLUSTER_ADDRESS"
 
-func init() {
+func AddWorkerCmd(rootCmd *cobra.Command) {
+	var workerCommand = &cobra.Command{
+		Use:   "worker",
+		Short: "Starts a worker for zbchaos jobs",
+		Long:  "Starts a worker for zbchaos jobs that executes zbchaos commands",
+		Run:   start_worker,
+	}
 	rootCmd.AddCommand(workerCommand)
-}
-
-var workerCommand = &cobra.Command{
-	Use:   "worker",
-	Short: "Starts a worker for zbchaos jobs",
-	Long:  "Starts a worker for zbchaos jobs that executes zbchaos commands",
-	Run:   start_worker,
 }
 
 func start_worker(cmd *cobra.Command, args []string) {
@@ -94,9 +93,9 @@ func handleZbChaosJob(client zbworker.JobClient, job entities.Job) {
 
 func runZbChaosCommand(args []string, ctx context.Context) error {
 	internal.LogInfo("Running command with args: %v ", args)
-	flags.reset()
-	rootCmd.SetArgs(args)
-	_, err := rootCmd.ExecuteContextC(ctx)
+	cmd := NewCmd()
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteContextC(ctx)
 	if err != nil {
 		return err
 	}

--- a/go-chaos/cmd/zeebePods.go
+++ b/go-chaos/cmd/zeebePods.go
@@ -19,13 +19,13 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func AddBrokersCommand(rootCmd *cobra.Command) {
+func AddBrokersCommand(rootCmd *cobra.Command, flags Flags) {
 	var getZeebeBrokersCmd = &cobra.Command{
 		Use:   "brokers",
 		Short: "Print the name of the Zeebe broker pods",
 		Long:  `Show all names of deployed Zeebe brokers, in the current kubernetes namespace.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			k8Client, err := internal.CreateK8Client()
+			k8Client, err := createK8ClientWithFlags(flags)
 			if err != nil {
 				panic(err)
 			}

--- a/go-chaos/cmd/zeebePods.go
+++ b/go-chaos/cmd/zeebePods.go
@@ -19,27 +19,27 @@ import (
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
 
-func init() {
+func AddBrokersCommand(rootCmd *cobra.Command) {
+	var getZeebeBrokersCmd = &cobra.Command{
+		Use:   "brokers",
+		Short: "Print the name of the Zeebe broker pods",
+		Long:  `Show all names of deployed Zeebe brokers, in the current kubernetes namespace.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			k8Client, err := internal.CreateK8Client()
+			if err != nil {
+				panic(err)
+			}
+
+			pods, err := k8Client.GetBrokerPodNames()
+			if err != nil {
+				panic(err)
+			}
+
+			for _, item := range pods {
+				internal.LogInfo("%s", item)
+			}
+		},
+	}
+
 	rootCmd.AddCommand(getZeebeBrokersCmd)
-}
-
-var getZeebeBrokersCmd = &cobra.Command{
-	Use:   "brokers",
-	Short: "Print the name of the Zeebe broker pods",
-	Long:  `Show all names of deployed Zeebe brokers, in the current kubernetes namespace.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		k8Client, err := internal.CreateK8Client()
-		if err != nil {
-			panic(err)
-		}
-
-		pods, err := k8Client.GetBrokerPodNames()
-		if err != nil {
-			panic(err)
-		}
-
-		for _, item := range pods {
-			internal.LogInfo("%s", item)
-		}
-	},
 }

--- a/go-chaos/internal/flags.go
+++ b/go-chaos/internal/flags.go
@@ -21,12 +21,6 @@ import (
 // Verbosity defines whether the functions should print verbose output
 var Verbosity = false
 
-// KubeConfigPath defines if a custom kube config should be used instead of the default one found by k8s
-var KubeConfigPath string
-
-// Namespace sets the namespace to be used instead of the namespace from the current kube context
-var Namespace string
-
 // JsonLogging defines whether the logging should be structured json logging
 var JsonLogging bool
 var JsonLogger zerolog.Logger

--- a/go-chaos/internal/flags.go
+++ b/go-chaos/internal/flags.go
@@ -15,21 +15,18 @@
 package internal
 
 import (
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"github.com/rs/zerolog"
 )
 
-// defines whether the functions should print verbose output
+// Verbosity defines whether the functions should print verbose output
 var Verbosity = false
 
-// defines if a custom kube config should be used instead of the default one found by k8s
+// KubeConfigPath defines if a custom kube config should be used instead of the default one found by k8s
 var KubeConfigPath string
 
-// sets the namespace to be used instead of the namespace from the current kube context
+// Namespace sets the namespace to be used instead of the namespace from the current kube context
 var Namespace string
 
-var ZeebeClientCredential zbc.CredentialsProvider
-
-// defines whether the logging should be structured json logging
+// JsonLogging defines whether the logging should be structured json logging
 var JsonLogging bool
 var JsonLogger zerolog.Logger

--- a/go-chaos/internal/k8helper.go
+++ b/go-chaos/internal/k8helper.go
@@ -43,8 +43,8 @@ func (c K8Client) GetCurrentNamespace() string {
 }
 
 // Creates a kubernetes client, based on the local kubeconfig
-func CreateK8Client() (K8Client, error) {
-	settings := findKubernetesSettings()
+func CreateK8Client(kubeConfigPath string, namespace string) (K8Client, error) {
+	settings := findKubernetesSettings(kubeConfigPath, namespace)
 	return createK8Client(settings)
 }
 
@@ -89,8 +89,8 @@ type KubernetesSettings struct {
 	namespace      string
 }
 
-func findKubernetesSettings() KubernetesSettings {
-	kubeconfig := KubeConfigPath
+func findKubernetesSettings(kubeConfigPath string, namespace string) KubernetesSettings {
+	kubeconfig := kubeConfigPath
 	if kubeconfig == "" {
 		// based on https://github.com/kubernetes/client-go/blob/master/examples/out-of-cluster-client-configuration/main.go
 		if home := homedir.HomeDir(); home != "" {
@@ -99,6 +99,6 @@ func findKubernetesSettings() KubernetesSettings {
 	}
 	return KubernetesSettings{
 		kubeConfigPath: kubeconfig,
-		namespace:      Namespace,
+		namespace:      namespace,
 	}
 }

--- a/go-chaos/internal/k8helper_test.go
+++ b/go-chaos/internal/k8helper_test.go
@@ -75,7 +75,7 @@ func Test_ResolveDefaultKubePath(t *testing.T) {
 	home := homedir.HomeDir()
 
 	// when
-	settings := findKubernetesSettings()
+	settings := findKubernetesSettings("", "")
 
 	// then
 	assert.Equal(t, strings.Join([]string{home, ".kube/config"}, "/"), settings.kubeConfigPath)


### PR DESCRIPTION
In order to not run into issues with global variables reused and reset during worker execute, we encapsulated all commands and make it available via `NewCMD` so everytime we have to create a new command to execute zbchaos in the workers. 

This allows us to always use a clean context.
