### PR TITLE
Improve worker logging

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -17,12 +17,18 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
 )
+
+func init() {
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+}
 
 type Flags struct {
 	partitionId        int

--- a/go-chaos/worker/chaos_worker.go
+++ b/go-chaos/worker/chaos_worker.go
@@ -90,7 +90,9 @@ func HandleZbChaosJob(client worker.JobClient, job entities.Job, commandRunner C
 	if *jobVariables.ClusterId != "" {
 		clusterAccessArgs = append(clusterAccessArgs, "--namespace", *jobVariables.ClusterId+"-zeebe", "--clientId", jobVariables.AuthenticationDetails.ClientId, "--clientSecret", jobVariables.AuthenticationDetails.ClientSecret, "--audience", jobVariables.AuthenticationDetails.Audience)
 	} // else we run local against our k8 context
+
 	commandArgs := append(clusterAccessArgs, jobVariables.Provider.Arguments...)
+	commandArgs = append(commandArgs, "--verbose", "--jsonLogging")
 
 	err = commandRunner(commandArgs, commandCtx)
 	if err != nil {


### PR DESCRIPTION
* enable higher precision for the logging timestamp. Previously we had the issue that the logs were not correctly sorted, since the timestamp were the same.
* always enable json and verbose logging in worker