### PR TITLE
fix: add pause after stress

### DIFF
--- a/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/stress-cpu-on-broker/experiment.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/production-s/stress-cpu-on-broker/experiment.json
@@ -52,6 +52,9 @@
                 "type": "process",
                 "path": "zbchaos",
                 "arguments": ["stress", "broker", "--cpu"]
+            },
+            "pauses": {
+                "after": 30
             }
         }
     ],


### PR DESCRIPTION
Previously we encountered several issues due to putting stress on broker, since this causes leader changes and then the deployment will not work. We should wait for a while and then try to verify the steady state