### PR TITLE
fix: only delete pvc

### DIFF
--- a/go-chaos/internal/volume.go
+++ b/go-chaos/internal/volume.go
@@ -33,11 +33,6 @@ func (c K8Client) DeletePvcOfBroker(podName string) error {
 		return err
 	}
 
-	LogInfo("Deleting PV %s", pvc.Spec.VolumeName)
-	err = c.Clientset.CoreV1().PersistentVolumes().Delete(context.TODO(), pvc.Spec.VolumeName, metav1.DeleteOptions{})
-	if err != nil {
-		return err
-	}
 	LogInfo("Deleting PVC %s in namespace %s ", pvc.Name, c.GetCurrentNamespace())
 	err = c.Clientset.CoreV1().PersistentVolumeClaims(c.GetCurrentNamespace()).Delete(context.TODO(), volume.PersistentVolumeClaim.ClaimName, metav1.DeleteOptions{})
 	if err != nil {


### PR DESCRIPTION
Reclaim policy of pvc is "Delete", which means it will be automatically deleted when PV is deleted and it is no longer attached to a pod. 

When we delete both PVC and PV together, PV is not getting deleted. We don't know yet why this happens. But we (with @multani ) verified that when we delete PVC, the PV is also getting deleted.

https://github.com/camunda-cloud/team-sre/issues/253#issuecomment-1609259799