### PR TITLE
fix(setup): runAs root to install tooling

### DIFF
--- a/go-chaos/go.mod
+++ b/go-chaos/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v23.0.5+incompatible // indirect
+	github.com/docker/docker v23.0.7-0.20230730020554-801e90549aac+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/go-chaos/go.sum
+++ b/go-chaos/go.sum
@@ -34,8 +34,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v23.0.5+incompatible h1:DaxtlTJjFSnLOXVNUBU1+6kXGz2lpDoEAH6QoxaSg8k=
-github.com/docker/docker v23.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v23.0.7-0.20230730020554-801e90549aac+incompatible h1:kfAcNSlJ1QftxUMaq6h+zmRDnq/IcL6dUxOKUhKTH+8=
+github.com/docker/docker v23.0.7-0.20230730020554-801e90549aac+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/go-chaos/internal/network.go
+++ b/go-chaos/internal/network.go
@@ -32,6 +32,7 @@ func (c K8Client) ApplyNetworkPatch() error {
 		return err
 	}
 
+	// We need to run the container with root to allow install tooling and give it network admin capabilities
 	patch := []byte(`{
 		"spec":{
 			"template":{
@@ -40,6 +41,7 @@ func (c K8Client) ApplyNetworkPatch() error {
 						{
 							"name": "zeebe",
 							"securityContext":{
+								"runAsUser": 0,
 								"capabilities":{
 									"add":["NET_ADMIN"]
 								}
@@ -61,6 +63,7 @@ func (c K8Client) ApplyNetworkPatchOnGateway() error {
 		return err
 	}
 
+	// We need to run the container with root to allow install tooling and give it network admin capabilities
 	patch := []byte(`{
 		"spec":{
 			"template":{
@@ -69,6 +72,7 @@ func (c K8Client) ApplyNetworkPatchOnGateway() error {
 						{
 							"name": "zeebe-gateway",
 							"securityContext":{
+								"runAsUser": 0,
 								"capabilities":{
 									"add":["NET_ADMIN"]
 								}


### PR DESCRIPTION
Since https://github.com/camunda/zeebe/pull/13418 got merged the zeebe container runs with an unprivileged `zeebe` user.

As the chaos tooling makes use of apt to install some tools needed to e.g. stress the cpu or modify ip routes we need to also overwrite the `runAsUser` to root to make that possible still.

Unfortnately the k8s exec API is not offering a way to override the user see https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/exec/exec.go#L104

The first commit resolves an issue that lead to test failure, see https://github.com/testcontainers/testcontainers-go/issues/1359#issuecomment-1657098312