### PR TITLE
fix: publish message with 1h ttl

### DIFF
--- a/go-chaos/cmd/publish.go
+++ b/go-chaos/cmd/publish.go
@@ -48,7 +48,7 @@ func AddPublishCmd(rootCmd *cobra.Command, flags *Flags) {
 
 			internal.LogVerbose("Send message '%s', with correaltion key '%s' (ASCII: %d) ", flags.msgName, correlationKey, int(correlationKey[0]))
 
-			messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(flags.msgName).CorrelationKey(correlationKey).TimeToLive(time.Minute * 5).Send(context.TODO())
+			messageResponse, err := zbClient.NewPublishMessageCommand().MessageName(flags.msgName).CorrelationKey(correlationKey).TimeToLive(time.Hour * 1).Send(context.TODO())
 			partitionIdFromKey := internal.ExtractPartitionIdFromKey(messageResponse.Key)
 
 			internal.LogInfo("Message was sent and returned key %d, which corresponds to partition: %d", messageResponse.Key, partitionIdFromKey)


### PR DESCRIPTION
Messages were published with a TTL of 5 minutes, which means the engine buffers them for 5 minutes. The buffered message is then expected to correlate to a process instance's event later in the chaos experiment.

However, in some cases, the chaos experiment takes longer than these 5 minutes. When the message is expired, the chaos experiment can no longer succeed even though it retries for an hour. For example, this occurred in the action:
- Should be able to create a process instance and await the message correlation

Changing the TTL of the published message fixes this problem by buffering the message for the same duration as the retry period.