### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/publishZbchaosImage.yml
+++ b/.github/workflows/publishZbchaosImage.yml
@@ -21,7 +21,7 @@ jobs:
             // noinspection JSUnresolvedVariable
             
             const imageName = `gcr.io/zeebe-io/zbchaos`
-            const versionRegex = /zbchaos v(?<version>\d+\.\d+\.\d+)/i
+            const versionRegex = /zbchaos-v(?<version>\d+\.\d+\.\d+)/i
             if (context.eventName === "release") {
                 const versionMatch = context.payload.release.name.match(versionRegex)
                 if (versionMatch == null) {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release zbchaos
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Release and tag name'     
+        required: true
+        default: 'zbchaosv0.X.0'
+
+env:
+  GO_VERSION: 1.19
+
+jobs:
+ go-release:
+    name: Run Go CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go-chaos
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_VERSION: ${{ github.event.inputs.release }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "${{ env.GO_VERSION }}"
+    - name: "Build zbchaos"
+      run: ./build.sh
+    - name: "Create GitHub release"
+      # Use github CLI to create the release
+      #
+      #  * Per default set to latest, right now everything is latest
+      #  * Automatically generate notes based on PR's
+      #  * Dist folder will be uploaded and attached to the release
+      #  * Tag will be automatically created
+      run: gh create release $RELEASE --generate-notes ./dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       release:
         description: 'Release and tag name'     
         required: true
-        default: 'zbchaosv0.X.0'
+        default: 'zbchaos-v1.X.0'
 
 env:
   GO_VERSION: 1.19


### PR DESCRIPTION
I don't want to follow the manual guide anymore.

This PR adds a new workflow which allows to manually trigger zbchaos release, following the guide documented in the README https://github.com/zeebe-io/zeebe-chaos/blob/zbchaosv1.3.0/go-chaos/README.md

What is missing to autodeploy the zbchaos docker image, after it is created by the other github action. But step by step.

Resources:

 * https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows
 * https://github.com/zeebe-io/zeebe-chaos/blob/zbchaosv1.3.0/go-chaos/README.md
 * https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/ 