### PR TITLE
fix: use new app label for zeebe gateway saas

### DIFF
--- a/go-chaos/internal/labels.go
+++ b/go-chaos/internal/labels.go
@@ -62,7 +62,7 @@ func getSaasGatewayLabels() string {
 	// For backwards compatability the brokers kept the gateway labels, for a statefulset the labels are not modifiable
 	// To still be able to distinguish the standalone gateway with the broker, the gateway got a new label.
 	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{"app.kubernetes.io/app": "zeebe", "app.kubernetes.io/component": "standalone-gateway"},
+		MatchLabels: map[string]string{"app.kubernetes.io/app": "zeebe-gateway", "app.kubernetes.io/component": "standalone-gateway"},
 	}
 	return labels.Set(labelSelector.MatchLabels).String()
 }

--- a/go-chaos/internal/labels_test.go
+++ b/go-chaos/internal/labels_test.go
@@ -55,7 +55,7 @@ func Test_shouldGetSelfManagedGatewayLabels(t *testing.T) {
 
 func Test_shouldGetSaasGatewayLabels(t *testing.T) {
 	// given
-	var expected = "app.kubernetes.io/app=zeebe,app.kubernetes.io/component=standalone-gateway"
+	var expected = "app.kubernetes.io/app=zeebe-gateway,app.kubernetes.io/component=standalone-gateway"
 
 	// when
 	actual := getSaasGatewayLabels()


### PR DESCRIPTION
See [slack](https://camunda.slack.com/archives/C013MEVQ4M9/p1697628052664839).

This aligns the labels to the change done with https://github.com/camunda-cloud/camunda-operator/pull/2032/files