### PR TITLE
Use docker image for the workers

### DIFF
--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -85,7 +85,7 @@ The workers can be used as part of some chaos experiments to complete process in
 			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
-			err = k8Client.CreateWorkerDeployment()
+			err = k8Client.CreateWorkerDeployment(DockerImageTag)
 			ensureNoError(err)
 
 			internal.LogInfo("Worker successfully deployed to the current namespace: %s", k8Client.GetCurrentNamespace())

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -79,6 +79,7 @@ var Version = "development"
 var Commit = "HEAD"
 var Verbose bool
 var JsonLogging bool
+var DockerImageTag string = "zeebe"
 
 func NewCmd() *cobra.Command {
 	flags := Flags{}
@@ -102,6 +103,7 @@ func NewCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
 	rootCmd.PersistentFlags().StringVar(&flags.kubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "", "connect to the given namespace")
+	rootCmd.PersistentFlags().StringVarP(&DockerImageTag, "dockerImageTag", "", "", "use the given docker image tag for deployed resources, e.g. worker/starter")
 
 	AddBackupCommand(rootCmd, &flags)
 	AddBrokersCommand(rootCmd, &flags)

--- a/go-chaos/integration/integration_test.go
+++ b/go-chaos/integration/integration_test.go
@@ -62,6 +62,7 @@ func Test_ShouldBeAbleToRunExperiments(t *testing.T) {
 	vars := make(map[string]interface{})
 	vars["clusterPlan"] = "test" // specifies the cluster plan for which we read the experiments
 	vars["clusterId"] = ""       // need to be set to empty string, otherwise we run into a SIGSEG
+	vars["zeebeImage"] = "gcr.io/zeebe-io/zeebe:SNAPSHOT"
 
 	commandStep3, err := zeebeClient.NewCreateInstanceCommand().BPMNProcessId("chaosToolkit").LatestVersion().VariablesFromMap(vars)
 	require.NoError(t, err)

--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: gcr.io/zeebe-io/worker:zeebe
+          image: gcr.io/zeebe-io/worker:REPLACE
           imagePullPolicy: Always
           env:
             - name: JAVA_OPTIONS

--- a/go-chaos/worker/chaos_worker.go
+++ b/go-chaos/worker/chaos_worker.go
@@ -55,7 +55,7 @@ type ZbChaosVariables struct {
 	ClusterId *string
 	// the zeebe docker image used for the chaos experiment
 	// used later for workers and starter to use the right client versions
-	ZeebeImage *string
+	ZeebeImage string
 	// the chaos provider, which contain details to the chaos experiment
 	Provider ChaosProvider
 }
@@ -93,9 +93,9 @@ func HandleZbChaosJob(client worker.JobClient, job entities.Job, commandRunner C
 		clusterAccessArgs = append(clusterAccessArgs, "--namespace", *jobVariables.ClusterId+"-zeebe")
 	} // else we run local against our k8 context
 
-	dockerImageSplit := strings.Split(*jobVariables.ZeebeImage, ":")
+	dockerImageSplit := strings.Split(jobVariables.ZeebeImage, ":")
 	if len(dockerImageSplit) <= 1 {
-		errorMsg := fmt.Sprintf("Error on running command. [key: %d, variables: %v]. Error: %s", job.Key, jobVariables, "Expected to read a dockerImage and split on ':', but read "+*jobVariables.ZeebeImage)
+		errorMsg := fmt.Sprintf("%s. Error on running command. [key: %d, variables: %v].", "Expected to read a dockerImage and split on ':', but read '"+jobVariables.ZeebeImage+"'", job.Key, job.Variables)
 		internal.LogInfo(errorMsg)
 		_, _ = client.NewFailJobCommand().JobKey(job.Key).Retries(job.Retries - 1).ErrorMessage(errorMsg).Send(ctx)
 		return


### PR DESCRIPTION
Allow to specify a dockerImageTag as global parameter, to be used by the deployed worker (and maybe later starter, etc.)

This is to make sure that we use the same client version as the deployed/target zeebe cluster.

closes https://github.com/zeebe-io/zeebe-chaos/issues/446