### PR TITLE
Allow injecting polling delay into worker deployment

### DIFF
--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -85,7 +85,7 @@ The workers can be used as part of some chaos experiments to complete process in
 			k8Client, err := createK8ClientWithFlags(flags)
 			ensureNoError(err)
 
-			err = k8Client.CreateWorkerDeployment(DockerImageTag)
+			err = k8Client.CreateWorkerDeployment(DockerImageTag, flags.pollingDelayMs)
 			ensureNoError(err)
 
 			internal.LogInfo("Worker successfully deployed to the current namespace: %s", k8Client.GetCurrentNamespace())
@@ -123,5 +123,7 @@ The process models allow to execute chaos experiments.`,
 		"Specify how many different versions of a default BPMN and DMN model should be deployed. Useful for testing deployment distribution.")
 
 	deployCmd.AddCommand(deployWorkerCmd)
+	deployWorkerCmd.Flags().IntVar(&flags.pollingDelayMs, "pollingDelay", 1, "Specifies the worker's polling interval")
+
 	deployCmd.AddCommand(deployChaosModels)
 }

--- a/go-chaos/cmd/deploy.go
+++ b/go-chaos/cmd/deploy.go
@@ -123,7 +123,7 @@ The process models allow to execute chaos experiments.`,
 		"Specify how many different versions of a default BPMN and DMN model should be deployed. Useful for testing deployment distribution.")
 
 	deployCmd.AddCommand(deployWorkerCmd)
-	deployWorkerCmd.Flags().IntVar(&flags.pollingDelayMs, "pollingDelay", 1, "Specifies the worker's polling interval")
+	deployWorkerCmd.Flags().IntVar(&flags.pollingDelayMs, "pollingDelay", 1, "Specifies the worker's polling interval in milliseconds")
 
 	deployCmd.AddCommand(deployChaosModels)
 }

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -106,7 +106,7 @@ func NewCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&JsonLogging, "jsonLogging", "", false, "json logging output")
 	rootCmd.PersistentFlags().StringVar(&flags.kubeConfigPath, "kubeconfig", "", "path the the kube config that will be used")
 	rootCmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "", "connect to the given namespace")
-	rootCmd.PersistentFlags().StringVarP(&DockerImageTag, "dockerImageTag", "", "", "use the given docker image tag for deployed resources, e.g. worker/starter")
+	rootCmd.PersistentFlags().StringVarP(&DockerImageTag, "dockerImageTag", "", DockerImageTag, "use the given docker image tag for deployed resources, e.g. worker/starter")
 
 	AddBackupCommand(rootCmd, &flags)
 	AddBrokersCommand(rootCmd, &flags)

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -46,6 +46,9 @@ type Flags struct {
 	broker2Role        string
 	broker2NodeId      int
 
+	// deploy worker
+	pollingDelayMs int
+
 	// backup
 	backupId string
 

--- a/go-chaos/internal/deployment.go
+++ b/go-chaos/internal/deployment.go
@@ -20,10 +20,13 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+
 	v12 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"strings"
 )
 
 // k8Deployments holds our static k8 manifests, which are copied with the go:embed directive
@@ -48,10 +51,12 @@ func (c K8Client) getGatewayDeployment() (*v12.Deployment, error) {
 	}
 	return &deploymentList.Items[0], err
 }
+
 func (c K8Client) CreateWorkerDeploymentDefault() error {
-	return c.CreateWorkerDeployment("zeebe")
+	return c.CreateWorkerDeployment("zeebe", 1)
 }
-func (c K8Client) CreateWorkerDeployment(dockerImageTag string) error {
+
+func (c K8Client) CreateWorkerDeployment(dockerImageTag string, pollingDelayMs int) error {
 	workerBytes, err := k8Deployments.ReadFile("manifests/worker.yaml")
 	if err != nil {
 		return err
@@ -71,15 +76,12 @@ func (c K8Client) CreateWorkerDeployment(dockerImageTag string) error {
 		// We are in self-managed environment
 		// We have to update the service url such that our workers can connect
 		// We expect that the used helm release name is == to the namespace name
-
-		// JAVA_OPTIONS
-		envVar := container.Env[0]
-		envVar.Value = strings.Replace(envVar.Value, "zeebe-service:26500", fmt.Sprintf("%s-zeebe-gateway:26500", c.GetCurrentNamespace()), 1)
-		container.Env[0] = envVar
+		replaceJavaOptions(container, "zeebe-service:26500", fmt.Sprintf("%s-zeebe-gateway:26500", c.GetCurrentNamespace()))
 	}
-	container.Image = strings.Replace(container.Image, "REPLACE", dockerImageTag, 1)
-	_, err = c.Clientset.AppsV1().Deployments(c.GetCurrentNamespace()).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	container.Image = strings.Replace(container.Image, "{{ imageTag }}", dockerImageTag, 1)
+	replaceJavaOptions(container, "{{ pollingDelay }}", strconv.FormatInt(int64(pollingDelayMs), 10)+"ms")
 
+	_, err = c.Clientset.AppsV1().Deployments(c.GetCurrentNamespace()).Create(context.TODO(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		if err.Error() == "deployments.apps \"worker\" already exists" {
 			LogInfo("Workers have already deployed, update deployment.")
@@ -91,4 +93,11 @@ func (c K8Client) CreateWorkerDeployment(dockerImageTag string) error {
 		}
 	}
 	return err
+}
+
+// Replaces a given string for a substitution in the JAVA_OPTIONS env var
+func replaceJavaOptions(container *v1.Container, value string, subst string) {
+	envVar := container.Env[0]
+	envVar.Value = strings.Replace(envVar.Value, value, subst, 1)
+	container.Env[0] = envVar
 }

--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: gcr.io/zeebe-io/worker:REPLACE
+          image: gcr.io/zeebe-io/worker:{{ imageTag }}
           imagePullPolicy: Always
           env:
             - name: JAVA_OPTIONS
@@ -24,7 +24,7 @@ spec:
                 -Dapp.brokerUrl=zeebe-service:26500
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=10
-                -Dapp.worker.pollingDelay=1ms
+                -Dapp.worker.pollingDelay={{ pollingDelay }}
                 -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL


### PR DESCRIPTION
**Description**

This PR allows injecting the polling delay into the worker deployment. The polling delay is given via command line as milliseconds because I couldn't be bothered to figure out how to convert to a nicer type from string :upside_down_face: 

This will now allow us to "disable" polling for job push experiments.

It also fixes setting a default value for the worker Docker image tag, as it was previously defaulting to `""` when omitted.

