### PR TITLE
Experiment: job worker stream is resilient to gateway crashes

### DIFF
--- a/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/restart.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/restart.json
@@ -1,0 +1,79 @@
+{
+  "version": "0.1.0",
+  "title": "Job push gateway restart gracefully experiment",
+  "description": "Job workers with streaming enabled should be fault-tolerant. The stream should be recreated and reused to complete instances even after gateway restarts.",
+  "contributions": {
+      "performance": "high",
+      "reliability": "high",
+      "availability": "high"
+  },
+  "steady-state-hypothesis": {
+      "title": "Zeebe is alive",
+      "probes": [
+          {
+              "name": "All pods should be ready",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "readiness"],
+                  "timeout": 900
+              }
+          },
+          {
+              "name": "Can deploy process model",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["deploy", "process"],
+                  "timeout": 900
+              }
+          },
+          {
+            "name": "Can deploy workers",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["deploy", "worker", "--pollingDelay", "86400000"],
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+          },
+          {
+              "name": "Should be able to create process instances",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "instance-creation", "--awaitResult"],
+                  "timeout": 900
+              }
+          }
+      ]
+  },
+  "method": [
+    {
+        "name": "Restart gateways",
+        "type": "probe",
+        "tolerance": 0,
+        "provider": {
+            "type": "process",
+            "path": "zbchaos",
+            "arguments": ["restart", "gateway", "--all"],
+            "timeout": 900
+        },
+        "pauses": {
+            "after": 5
+        }
+    }
+  ],
+  "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/restart.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/restart.json
@@ -69,9 +69,6 @@
             "path": "zbchaos",
             "arguments": ["restart", "gateway", "--all"],
             "timeout": 900
-        },
-        "pauses": {
-            "after": 5
         }
     }
   ],

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/terminate.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/terminate.json
@@ -1,0 +1,79 @@
+{
+  "version": "0.1.0",
+  "title": "Job push gateway restart gracefully experiment",
+  "description": "Job workers with streaming enabled should be fault-tolerant. The stream should be recreated and reused to complete instances even after gateway restarts.",
+  "contributions": {
+      "performance": "high",
+      "reliability": "high",
+      "availability": "high"
+  },
+  "steady-state-hypothesis": {
+      "title": "Zeebe is alive",
+      "probes": [
+          {
+              "name": "All pods should be ready",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "readiness"],
+                  "timeout": 900
+              }
+          },
+          {
+              "name": "Can deploy process model",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["deploy", "process"],
+                  "timeout": 900
+              }
+          },
+          {
+            "name": "Can deploy workers",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["deploy", "worker", "--pollingDelay", "86400000"],
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+          },
+          {
+              "name": "Should be able to create process instances",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "instance-creation", "--awaitResult"],
+                  "timeout": 900
+              }
+          }
+      ]
+  },
+  "method": [
+    {
+        "name": "Restart gateways",
+        "type": "probe",
+        "tolerance": 0,
+        "provider": {
+            "type": "process",
+            "path": "zbchaos",
+            "arguments": ["terminate", "gateway", "--all"],
+            "timeout": 900
+        },
+        "pauses": {
+            "after": 5
+        }
+    }
+  ],
+  "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/terminate.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/job-push-gateway/terminate.json
@@ -69,9 +69,6 @@
             "path": "zbchaos",
             "arguments": ["terminate", "gateway", "--all"],
             "timeout": 900
-        },
-        "pauses": {
-            "after": 5
         }
     }
   ],

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
@@ -39,6 +39,14 @@ experiments:
   - path: worker-restart/experiment.json
     clusterPlans:
       - production-s
+  - path: job-push-gateway/restart.json
+    clusterPlans:
+      - production-s
+    minVersion: 8.4
+  - path: job-push-gateway/terminate.json
+    clusterPlans:
+      - production-s
+    minVersion: 8.4
   # only for testing
   - path: test/experiment.json
     clusterPlans:

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
@@ -47,6 +47,14 @@ experiments:
     clusterPlans:
       - production-s
     minVersion: 8.4
+  - path: worker-resilience/gateway-restart.json
+    clusterPlans:
+      - production-s
+    maxVersion: 8.3
+  - path: worker-resilience/gateway-terminate.json
+    clusterPlans:
+      - production-s
+    minVersion: 8.3
   # only for testing
   - path: test/experiment.json
     clusterPlans:

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/worker-resilience/gateway-restart.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/worker-resilience/gateway-restart.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.1.0",
+  "title": "Gateways restart",
+  "description": "Job workers should be fault-tolerant, even if all gateways are restarted.",
+  "contributions": {
+      "reliability": "high",
+      "availability": "high"
+  },
+  "steady-state-hypothesis": {
+      "title": "Zeebe is alive",
+      "probes": [
+          {
+              "name": "All pods should be ready",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "readiness"],
+                  "timeout": 900
+              }
+          },
+          {
+              "name": "Can deploy process model",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["deploy", "process"],
+                  "timeout": 900
+              }
+          },
+          {
+            "name": "Can deploy workers",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["deploy", "worker"],
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+          },
+          {
+              "name": "Should be able to create process instances",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "instance-creation", "--awaitResult"],
+                  "timeout": 900
+              }
+          }
+      ]
+  },
+  "method": [
+    {
+        "name": "Restart gateways",
+        "type": "probe",
+        "tolerance": 0,
+        "provider": {
+            "type": "process",
+            "path": "zbchaos",
+            "arguments": ["restart", "gateway", "--all"],
+            "timeout": 900
+        }
+    }
+  ],
+  "rollbacks": []
+}

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/worker-resilience/gateway-terminate.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/worker-resilience/gateway-terminate.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.1.0",
+  "title": "Gateways restart",
+  "description": "Job workers should be fault-tolerant, even if all gateways crash.",
+  "contributions": {
+      "reliability": "high",
+      "availability": "high"
+  },
+  "steady-state-hypothesis": {
+      "title": "Zeebe is alive",
+      "probes": [
+          {
+              "name": "All pods should be ready",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "readiness"],
+                  "timeout": 900
+              }
+          },
+          {
+              "name": "Can deploy process model",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["deploy", "process"],
+                  "timeout": 900
+              }
+          },
+          {
+            "name": "Can deploy workers",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["deploy", "worker"],
+                "timeout": 900
+            },
+            "pauses": {
+                "after": 5
+            }
+          },
+          {
+              "name": "Should be able to create process instances",
+              "type": "probe",
+              "tolerance": 0,
+              "provider": {
+                  "type": "process",
+                  "path": "zbchaos",
+                  "arguments": ["verify", "instance-creation", "--awaitResult"],
+                  "timeout": 900
+              }
+          }
+      ]
+  },
+  "method": [
+    {
+        "name": "Restart gateways",
+        "type": "probe",
+        "tolerance": 0,
+        "provider": {
+            "type": "process",
+            "path": "zbchaos",
+            "arguments": ["terminate", "gateway", "--all"],
+            "timeout": 900
+        }
+    }
+  ],
+  "rollbacks": []
+}

--- a/go-chaos/worker/chaos_worker_test.go
+++ b/go-chaos/worker/chaos_worker_test.go
@@ -186,7 +186,8 @@ func Test_ShouldSendExperimentsForClusterPlan(t *testing.T) {
 	// then
 	assert.True(t, fakeJobClient.Succeeded)
 	assert.Equal(t, 123, fakeJobClient.Key)
-	experiments, err := chaos_experiments.ReadExperimentsForClusterPlan("Production - S", "8.4.0-SNAPSHOT")
+	// as we don't have a version in this test, we should omit version bounded experiments
+	experiments, err := chaos_experiments.ReadExperimentsForClusterPlan("Production - S", "")
 	require.NoError(t, err)
 	assert.Equal(t, experiments, fakeJobClient.Variables)
 }


### PR DESCRIPTION
**Description**

Adds two new experiments which are for 8.4 only, ensuring job push remains resilient even when gateways are restarted.

Tested manually using the integration test.

closes #442 