### PR TITLE
feat(zbchaos): query current cluster topology

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -1,0 +1,130 @@
+// Copyright 2023 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/zeebe-io/zeebe-chaos/go-chaos/internal"
+	"io"
+	"net/http"
+)
+
+func AddClusterCommands(rootCmd *cobra.Command, flags *Flags) {
+	var clusterCommand = &cobra.Command{
+		Use:   "cluster",
+		Short: "Interact with the Cluster API",
+		Long:  "Can be used query cluster topology and to request dynamic scaling",
+	}
+	var statusCommand = &cobra.Command{
+		Use:   "status",
+		Short: "Queries the current cluster topology",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return queryTopology(flags)
+		},
+	}
+
+	rootCmd.AddCommand(clusterCommand)
+	clusterCommand.AddCommand(statusCommand)
+}
+
+func queryTopology(flags *Flags) error {
+	k8Client, err := createK8ClientWithFlags(flags)
+	if err != nil {
+		panic(err)
+	}
+
+	err = k8Client.AwaitReadiness()
+	if err != nil {
+		return err
+	}
+
+	port := 9600
+	closePortForward := k8Client.MustGatewayPortForward(port, port)
+	defer closePortForward()
+	url := fmt.Sprintf("http://localhost:%d/actuator/cluster", port)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var topology CurrentTopology
+	err = json.Unmarshal(body, &topology)
+	if err != nil {
+		return err
+	}
+
+	formatted, err := json.MarshalIndent(topology, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	internal.LogInfo(fmt.Sprintf("Current topology: %s", string(formatted)))
+	return err
+
+}
+
+type CurrentTopology struct {
+	ChangeId      int32
+	Brokers       []BrokerState
+	LastChange    *LastChange
+	PendingChange *TopologyChange
+}
+
+type BrokerState struct {
+	Id            int32
+	State         string
+	Version       int64
+	LastUpdatedAt string
+	Partitions    []PartitionState
+}
+
+type PartitionState struct {
+	Id       int32
+	State    string
+	Priority int32
+}
+
+type LastChange struct {
+	Id          int64
+	Status      string
+	StartedAt   string
+	CompletedAt string
+}
+
+type TopologyChange struct {
+	Id              int64
+	Status          string
+	StartedAt       string
+	CompletedAt     string
+	InternalVersion int64
+	Completed       []Operation
+	Pending         []Operation
+}
+
+type Operation struct {
+	Operation   string
+	BrokerId    int32
+	PartitionId int32
+	Priority    int32
+}

--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -29,7 +29,7 @@ func AddClusterCommands(rootCmd *cobra.Command, flags *Flags) {
 	var clusterCommand = &cobra.Command{
 		Use:   "cluster",
 		Short: "Interact with the Cluster API",
-		Long:  "Can be used query cluster topology and to request dynamic scaling",
+		Long:  "Can be used to query cluster topology and to request dynamic scaling",
 	}
 	var statusCommand = &cobra.Command{
 		Use:   "status",

--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -67,7 +67,7 @@ func printCurrentTopology(flags *Flags) error {
 	closePortForward := k8Client.MustGatewayPortForward(port, port)
 	defer closePortForward()
 
-	topology, err := queryTopology(port)
+	topology, err := QueryTopology(port)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func waitForChange(flags *Flags) error {
 	timeout := (time.Minute * 25)
 	iterations := int(timeout / interval)
 	for i := 0; i < int(iterations); i++ {
-		topology, err := queryTopology(port)
+		topology, err := QueryTopology(port)
 		if err != nil {
 			return err
 		}
@@ -154,11 +154,14 @@ func describeChangeStatus(topology *CurrentTopology, changeId int64) ChangeStatu
 	}
 }
 
-func queryTopology(port int) (*CurrentTopology, error) {
+func QueryTopology(port int) (*CurrentTopology, error) {
 	url := fmt.Sprintf("http://localhost:%d/actuator/cluster", port)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("expected status code 200 but got %d", resp.StatusCode)
 	}
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()

--- a/go-chaos/cmd/cluster_test.go
+++ b/go-chaos/cmd/cluster_test.go
@@ -1,0 +1,107 @@
+// Copyright 2023 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DescribeChangeStatusWithPending(t *testing.T) {
+	// given
+	topology := CurrentTopology{
+		Version: 1,
+		Brokers: []BrokerState{},
+		LastChange: &LastChange{
+			Id:          2,
+			Status:      "COMPLETED",
+			StartedAt:   "2021-09-01T12:00:00.000Z",
+			CompletedAt: "2021-09-01T12:00:00.000Z",
+		},
+		PendingChange: &TopologyChange{
+			Id:              3,
+			Status:          "IN_PROGRESS",
+			StartedAt:       "2021-09-01T12:00:00.000Z",
+			CompletedAt:     "2021-09-01T12:00:00.000Z",
+			InternalVersion: 1,
+			Completed: []Operation{
+				{
+					Operation: "ADD",
+					BrokerId:  1,
+				},
+			},
+			Pending: []Operation{
+				{
+					Operation: "ADD_BROKER",
+					BrokerId:  2,
+				},
+			},
+		},
+	}
+
+	// then
+	assert.Equal(t, ChangeStatusPending, describeChangeStatus(&topology, 3))
+	assert.Equal(t, ChangeStatusCompleted, describeChangeStatus(&topology, 2))
+	assert.Equal(t, ChangeStatusOutdated, describeChangeStatus(&topology, 1))
+	assert.Equal(t, ChangeStatusUnknown, describeChangeStatus(&topology, 4))
+}
+
+func Test_DescribeChangeStatusWithoutChanges(t *testing.T) {
+	// given
+	topology := CurrentTopology{
+		Version:       1,
+		Brokers:       []BrokerState{},
+		LastChange:    nil,
+		PendingChange: nil,
+	}
+
+	// then
+	assert.Equal(t, ChangeStatusUnknown, describeChangeStatus(&topology, 1))
+	assert.Equal(t, ChangeStatusUnknown, describeChangeStatus(&topology, 2))
+}
+
+func Test_DescribeChangeStatusWithoutCompleted(t *testing.T) {
+	// given
+	topology := CurrentTopology{
+		Version:    1,
+		Brokers:    []BrokerState{},
+		LastChange: nil,
+		PendingChange: &TopologyChange{
+			Id:              3,
+			Status:          "IN_PROGRESS",
+			StartedAt:       "2021-09-01T12:00:00.000Z",
+			CompletedAt:     "2021-09-01T12:00:00.000Z",
+			InternalVersion: 1,
+			Completed: []Operation{
+				{
+					Operation: "ADD",
+					BrokerId:  1,
+				},
+			},
+			Pending: []Operation{
+				{
+					Operation: "ADD_BROKER",
+					BrokerId:  2,
+				},
+			},
+		},
+	}
+
+	// then
+	assert.Equal(t, ChangeStatusUnknown, describeChangeStatus(&topology, 1))
+	assert.Equal(t, ChangeStatusPending, describeChangeStatus(&topology, 3))
+	assert.Equal(t, ChangeStatusUnknown, describeChangeStatus(&topology, 4))
+}

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -76,6 +76,9 @@ type Flags struct {
 	instanceCount  int
 	jobCount       int
 	jobType        string
+
+	// cluster
+	changeId int
 }
 
 var Version = "development"

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -123,6 +123,7 @@ func NewCmd() *cobra.Command {
 	AddVerifyCommands(rootCmd, &flags)
 	AddVersionCmd(rootCmd)
 	AddWorkerCmd(rootCmd)
+	AddClusterCommands(rootCmd, &flags)
 
 	return rootCmd
 }

--- a/go-chaos/integration/cluster_cmd_integration_test.go
+++ b/go-chaos/integration/cluster_cmd_integration_test.go
@@ -57,7 +57,7 @@ func Test_ShouldBeAbleToQueryTopology(t *testing.T) {
 
 func CreateZeebeContainer(t *testing.T, ctx context.Context) testcontainers.Container {
 	req := testcontainers.ContainerRequest{
-		Image:        "camunda/zeebe:SNAPSHOT",
+		Image:        "camunda/zeebe:8.4.0-alpha2",
 		ExposedPorts: []string{"26500/tcp", "9600/tcp"},
 		WaitingFor:   wait.ForHTTP("/actuator/health").WithPort("9600"),
 	}

--- a/go-chaos/integration/cluster_cmd_integration_test.go
+++ b/go-chaos/integration/cluster_cmd_integration_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/zeebe-io/zeebe-chaos/go-chaos/cmd"
+)
+
+func Test_ShouldBeAbleToQueryTopology(t *testing.T) {
+	// given
+	ctx := context.Background()
+	container := CreateZeebeContainer(t, ctx)
+	mappedPort, err := container.MappedPort(ctx, "9600/tcp")
+	require.NoError(t, err)
+
+	// when
+	var topology *cmd.CurrentTopology
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for {
+		topology, err = cmd.QueryTopology(mappedPort.Int())
+		require.NoError(t, err)
+		if topology.Version > 0 || ctx.Err() != nil {
+			break
+		}
+	}
+
+	// then
+	require.NoError(t, err)
+	require.NotNil(t, topology)
+	require.NotNil(t, topology.Brokers)
+	require.Equal(t, 1, len(topology.Brokers))
+	require.Equal(t, int32(1), topology.Version)
+	require.Nil(t, topology.LastChange)
+	require.Nil(t, topology.PendingChange)
+}
+
+func CreateZeebeContainer(t *testing.T, ctx context.Context) testcontainers.Container {
+	req := testcontainers.ContainerRequest{
+		Image:        "camunda/zeebe:SNAPSHOT",
+		ExposedPorts: []string{"26500/tcp", "9600/tcp"},
+		WaitingFor:   wait.ForHTTP("/actuator/health").WithPort("9600"),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	return container
+}


### PR DESCRIPTION
Adds a new command `zbchaos cluster status` that uses  `GET /actuator/cluster` under the hood and pretty-prints the deserialized response.

Part 1 of X for https://github.com/zeebe-io/zeebe-chaos/issues/458