### PR TITLE
fix: use correct JDK_JAVA_OPTIONS

### DIFF
--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -19,7 +19,7 @@ spec:
           image: gcr.io/zeebe-io/worker:{{ imageTag }}
           imagePullPolicy: Always
           env:
-            - name: JAVA_OPTIONS
+            - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dapp.brokerUrl=zeebe-service:26500
                 -Dzeebe.client.requestTimeout=62000


### PR DESCRIPTION
We need to use the newer java options, in order to configure our application otherwise it will not be picked up.