### PR TITLE
feat(zbchaos): add command for broker scaling

### DIFF
--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -80,7 +80,6 @@ type Flags struct {
 	// cluster
 	changeId int64
 	brokers  int
-	wait     bool
 }
 
 var Version = "development"

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -78,8 +78,9 @@ type Flags struct {
 	jobType        string
 
 	// cluster
-	changeId int
+	changeId int64
 	brokers  int
+	wait     bool
 }
 
 var Version = "development"

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -79,6 +79,7 @@ type Flags struct {
 
 	// cluster
 	changeId int
+	brokers  int
 }
 
 var Version = "development"

--- a/go-chaos/cmd/topology.go
+++ b/go-chaos/cmd/topology.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -67,6 +68,9 @@ func writeTopologyToOutput(output io.Writer, response *pb.TopologyResponse) {
 }
 
 func writeTopology(response *pb.TopologyResponse, writer *tabwriter.Writer) {
+	sort.Slice(response.Brokers, func(i, j int) bool {
+		return response.Brokers[i].NodeId < response.Brokers[j].NodeId
+	})
 	for _, broker := range response.Brokers {
 		addLineToWriter(writer, createBrokerTopologyString(response.PartitionsCount, broker))
 	}


### PR DESCRIPTION
Adds a new command that makes an API call to Zeebe to scale to the given amount of brokers and then scales up the statefulset accordingly. The command knows if it is scaling up or down to scale the statefulset first or last. The command always waits for completion as it can only scale down the statefulset after the change is applied.

Usage:

```
$ zbchaos cluster scale --brokers 5
```

Part 2/X of #458 