### PR TITLE
experiment: add experiment for borker-scaling

### DIFF
--- a/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
@@ -63,6 +63,10 @@ experiments:
     clusterPlans:
       - production-s
     minVersion: 8.3
+  - path: scaling/broker-scaling.json
+    clusterPlans:
+      - production-s
+    minVersion: 8.4
   # only for testing
   - path: test/experiment.json
     clusterPlans:

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/scaling/broker-scaling.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/scaling/broker-scaling.json
@@ -1,0 +1,89 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe scaling brokers experiment",
+    "description": "Brokers can be scaled up and Zeebe can continue processing after scaling up.",
+    "contributions": {
+        "reliability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "zbchaos",
+                    "arguments": ["verify", "readiness"],
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "name": "Deploy process model with catch event",
+            "type": "action",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["deploy", "process", "--processModelPath", "bpmn/msg-catch.bpmn"]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Publish message to partition three",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["publish", "--partitionId", "3"]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Scale up brokers",
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["cluster", "scale", "--brokers", "5"]
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["verify", "readiness"],
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create a process instance and await the message correlation that was published before scaling.",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["verify", "instance-creation",
+                    "--awaitResult",
+                    "--bpmnProcessId", "oneReceiveMsgEvent",
+                    "--variables", "{\"key\": \"2\"}"]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Scale down brokers (rollback)",
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": ["cluster", "scale", "--brokers", "3"]
+            }
+        }
+    ],
+    "rollbacks": []
+}


### PR DESCRIPTION
Add an experiment to verify that brokers can be scaled up and the processing continues after scaling. To verify processing continues, a message is published to partition 3. After scaling we expect it to be correlated to a new instance. 

The experiment can only be run on Production - S because it assumes a cluster size of 3 and partitions 3. 

I have not tested it. But since we have already manually tested `zbchaos scale` command, I assume this works.

related to https://github.com/camunda/zeebe/issues/15752 