### PR TITLE
fix: disable reconciliation before scaling in SaaS

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -79,6 +79,11 @@ func scaleCluster(flags *Flags) error {
 		return fmt.Errorf("cluster is already scaling")
 	}
 
+	err = k8Client.PauseReconciliation()
+	if err != nil {
+		return err
+	}
+
 	if len(currentTopology.Brokers) > flags.brokers {
 		_, err = scaleDownBrokers(k8Client, port, flags.brokers)
 	} else if len(currentTopology.Brokers) < flags.brokers {

--- a/go-chaos/internal/statefulset.go
+++ b/go-chaos/internal/statefulset.go
@@ -55,6 +55,7 @@ func (c K8Client) ScaleZeebeCluster(replicas int) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	statefulSets := c.Clientset.AppsV1().StatefulSets(namespace)
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		currentScale, err := statefulSets.GetScale(ctx, sfs.Name, meta.GetOptions{})


### PR DESCRIPTION
While testing E2E test with scaling, noticed that the current `zbchaos cluster scale` command do not work in SaaS because reconciliation is not disabled.