### PR TITLE
set correct labels for SM

### DIFF
--- a/go-chaos/internal/labels.go
+++ b/go-chaos/internal/labels.go
@@ -21,7 +21,10 @@ import (
 
 func getSelfManagedZeebeStatefulSetLabels() string {
 	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{"app.kubernetes.io/name": "zeebe"},
+		MatchLabels: map[string]string{
+			"app.kubernetes.io/component": "zeebe-broker",
+			"app.kubernetes.io/name":      "camunda-platform",
+		},
 	}
 	return labels.Set(labelSelector.MatchLabels).String()
 }


### PR DESCRIPTION
In Helm charts the labels have changed,
adjusting them to correctly match with the stateful set

closes https://github.com/zeebe-io/zeebe-chaos/issues/477