### PR TITLE
Saas detection error handling

### DIFF
--- a/go-chaos/internal/helper_test.go
+++ b/go-chaos/internal/helper_test.go
@@ -119,7 +119,9 @@ func (c *K8Client) createSaaSCRD(t *testing.T) {
 	_, err := c.DynamicClient.Resource(zeebeCrd).Create(context.TODO(), obj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	c.SaaSEnv = c.isSaaSEnvironment()
+	saas, err := c.isSaaSEnvironment()
+	require.NoError(t, err)
+	c.SaaSEnv = saas
 }
 
 func (c K8Client) CreateStatefulSetWithLabelsAndName(t *testing.T, selector *metav1.LabelSelector, name string) {

--- a/go-chaos/internal/k8helper.go
+++ b/go-chaos/internal/k8helper.go
@@ -73,7 +73,10 @@ func createK8Client(settings KubernetesSettings) (K8Client, error) {
 	}
 
 	client := K8Client{Clientset: clientset, ClientConfig: clientConfig, DynamicClient: dynamicClient}
-	client.SaaSEnv = client.isSaaSEnvironment()
+	client.SaaSEnv, err = client.isSaaSEnvironment()
+	if err != nil {
+		return client, err
+	}
 
 	if client.SaaSEnv {
 		LogVerbose("Running experiment in SaaS environment.")

--- a/go-chaos/internal/k8helper_test.go
+++ b/go-chaos/internal/k8helper_test.go
@@ -28,7 +28,7 @@ func Test_CreateK8ClientWithPath(t *testing.T) {
 	settings := KubernetesSettings{kubeConfigPath: "kubeconfigtest.yml"}
 
 	// when
-	client, err := createK8Client(settings)
+	client, err := internalCreateClient(settings)
 
 	// then
 	assert.NoError(t, err)
@@ -40,7 +40,7 @@ func Test_CreateK8ClientWithPath(t *testing.T) {
 func Test_ShouldReturnNamespace(t *testing.T) {
 	// given
 	settings := KubernetesSettings{kubeConfigPath: "kubeconfigtest.yml"}
-	client, err := createK8Client(settings)
+	client, err := internalCreateClient(settings)
 	require.NoError(t, err)
 
 	// when
@@ -57,7 +57,7 @@ func Test_ShouldReturnNamespace(t *testing.T) {
 func Test_ShouldReturnNamespaceOverride(t *testing.T) {
 	// given
 	settings := KubernetesSettings{kubeConfigPath: "kubeconfigtest.yml", namespace: "namespace-override"}
-	client, err := createK8Client(settings)
+	client, err := internalCreateClient(settings)
 	require.NoError(t, err)
 
 	// when


### PR DESCRIPTION

Paired with @oleschoenburg on this:

 * We agreed on to "simply" pass the error to the front, to the respective commands so they can either fail or do what ever
 * For errors indicating resource not-found we decided to return false, and use SM setting (as we expect this CRD not in the SM env)
 * We wrote some more tests for the error handling
 * I had to refactor a bit the client creation, so we test the right things here


closes #488 
closes #490 