### PR TITLE
fix: update image registry to correct one

### DIFF
--- a/go-chaos/internal/dataloss_sim_helper.go
+++ b/go-chaos/internal/dataloss_sim_helper.go
@@ -39,7 +39,7 @@ The init container exits and the zeebe container will be started.
 func (c K8Client) ApplyInitContainerPatch() error {
 	busyBoxImage := "busybox:latest"
 	if c.SaaSEnv {
-		busyBoxImage = "gcr.io/camunda-saas-registry/busybox:1.36.1"
+		busyBoxImage = "europe-docker.pkg.dev/camunda-saas-registry/vendor/busybox:1.36.1"
 	}
 	// apply config map
 	err := createConfigMapForInitContainer(c)

--- a/go-chaos/internal/dataloss_sim_helper_test.go
+++ b/go-chaos/internal/dataloss_sim_helper_test.go
@@ -35,7 +35,7 @@ func Test_ShouldApplyPatchInSaaS(t *testing.T) {
 	require.NoError(t, result)
 	statefulset, _ := k8Client.GetZeebeStatefulSet()
 	busyBoxImageName := statefulset.Spec.Template.Spec.InitContainers[0].Image
-	assert.Equal(t, "gcr.io/camunda-saas-registry/busybox:1.36.1", busyBoxImageName)
+	assert.Equal(t, "europe-docker.pkg.dev/camunda-saas-registry/vendor/busybox:1.36.1", busyBoxImageName)
 }
 
 func Test_ShouldApplyPatchInSelfManaged(t *testing.T) {


### PR DESCRIPTION
**Description**

Based on the [Slack thread](https://camunda.slack.com/archives/CQZGZ882Z/p1710145484340359?thread_ts=1710144915.404369&cid=CQZGZ882Z) our image registry is changed for int and dev. That causes our chaos tests to fail. This PR is attempting to fix the registry.