### PR TITLE
Add commands for force failover to a region

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -81,9 +81,6 @@ func scaleCluster(flags *Flags) error {
 	k8Client, err := createK8ClientWithFlags(flags)
 	ensureNoError(err)
 
-	err = k8Client.AwaitReadiness()
-	ensureNoError(err)
-
 	port, closePortForward := k8Client.MustGatewayPortForward(0, 9600)
 	defer closePortForward()
 	currentTopology, err := QueryTopology(port)

--- a/go-chaos/cmd/dataloss_sim.go
+++ b/go-chaos/cmd/dataloss_sim.go
@@ -104,14 +104,16 @@ func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags *Flags) {
 				panic(err)
 			}
 
-			// The pod is restarting after dataloss, so it takes longer to be ready
-			err = k8Client.AwaitPodReadiness(pod.Name, 10*time.Minute)
+			if flags.awaitReadiness {
+				// The pod is restarting after dataloss, so it takes longer to be ready
+				err = k8Client.AwaitPodReadiness(pod.Name, 10*time.Minute)
 
-			if err != nil {
-				internal.LogInfo("%s", err)
-				panic(err)
+				if err != nil {
+					internal.LogInfo("%s", err)
+					panic(err)
+				}
+				internal.LogInfo("Broker %d is recovered", flags.nodeId)
 			}
-			internal.LogInfo("Broker %d is recovered", flags.nodeId)
 		},
 	}
 
@@ -122,4 +124,5 @@ func AddDatalossSimulationCmd(rootCmd *cobra.Command, flags *Flags) {
 
 	datalossDelete.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
 	datalossRecover.Flags().IntVar(&flags.nodeId, "nodeId", 1, "Specify the id of the broker")
+	datalossRecover.Flags().BoolVar(&flags.awaitReadiness, "awaitReadiness", true, "If true wait until the recovered pod is ready")
 }

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -83,6 +83,9 @@ type Flags struct {
 	regionId          int32
 	regions           int32
 	replicationFactor int32
+
+	// dataloss
+	awaitReadiness bool
 }
 
 var Version = "development"

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -78,10 +78,11 @@ type Flags struct {
 	jobType        string
 
 	// cluster
-	changeId int64
-	brokers  int
-	regionId int32
-	regions  int32
+	changeId          int64
+	brokers           int
+	regionId          int32
+	regions           int32
+	replicationFactor int32
 }
 
 var Version = "development"

--- a/go-chaos/cmd/root.go
+++ b/go-chaos/cmd/root.go
@@ -80,6 +80,8 @@ type Flags struct {
 	// cluster
 	changeId int64
 	brokers  int
+	regionId int32
+	regions  int32
 }
 
 var Version = "development"


### PR DESCRIPTION
Related to https://github.com/camunda/zeebe-e2e-test/issues/421 

This PR adds commands for 
1. Force failover to one region `zbchaos forceFailover --regions=2 --regionId=1`
    * Removes region 0 and keeps the brokers from region 1 
2.  And adding the region back `zbchaos scale --brokers=4 --replicationFactor=4`
    * Re-uses the scale command, and added the parameter `replicationFactor`

The commands are manually tested on a benchmark cluster.

Also adds an optional `awaitReadiness` flag to `dataloss recover` command. When using the new API for failover, all brokers in the failed region must be started in parallel. Waiting for one broker to be ready before the others are started can prevent the failback from completing. 
