### PR TITLE
fix: update security context

### DIFF
--- a/go-chaos/internal/network.go
+++ b/go-chaos/internal/network.go
@@ -41,7 +41,7 @@ func (c K8Client) ApplyNetworkPatch() error {
 						{
 							"name": "zeebe",
 							"securityContext":{
-								"runAsUser": 0,
+								"runAsUser": 1000,
 								"capabilities":{
 									"add":["NET_ADMIN"]
 								}
@@ -72,7 +72,7 @@ func (c K8Client) ApplyNetworkPatchOnGateway() error {
 						{
 							"name": "zeebe-gateway",
 							"securityContext":{
-								"runAsUser": 0,
+								"runAsUser": 1000,
 								"capabilities":{
 									"add":["NET_ADMIN"]
 								}

--- a/go-chaos/internal/stress.go
+++ b/go-chaos/internal/stress.go
@@ -99,7 +99,7 @@ func (c K8Client) SetUserToRoot() error {
 						{
 							"name": "zeebe",
 							"securityContext":{
-								"runAsUser": 0
+								"runAsUser": 1000
 							}
 						}]
 				}


### PR DESCRIPTION
SRE updated security context on Zeebe containers that chaos tests' security contexts should also be updated accordingly. See related Slack discussion: https://camunda.slack.com/archives/CT702EPFH/p1712147652179179

closes #520 