### PR TITLE
Restructure flowcontrol blog post slightly

### DIFF
--- a/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
+++ b/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
@@ -2,28 +2,31 @@
 layout: posts
 title:  "Using flow control to handle bottleneck on exporting"
 date:   2024-07-25
-categories: 
-  - performance 
+categories:
+  - performance
 tags:
   - availability
 authors: rodrigo
 ---
 
-# Using flow control to handle bottleneck on exporting 
+# Using flow control to handle bottleneck on exporting
 
-With the Zeebe now having a unified flow control that protects from user commands that cannot be processed fast enough and from excessive writes, we wanted to test situations when exporting is degraded and how to configure the rate limits for writes to bring the cluster back to a balanced/safe state.
+Zeebe 8.6 introduces a new unified flow control mechanism that is able to limit user commands (by default it tries to achieve 200ms response times) and rate limit writes of new records in general (disabled by default).
+Limiting the write rate is a new feature that can be used to prevent building up an excessive exporting backlog.
+There are two ways to limit the write rate, either by setting a static limit or by enabling throttling that dynamically adjust the write rate based on the exporting backlog and rate.
+In these experiments, we will test both ways of limiting the write rate and observe the effects on processing and exporting.
 
 **TL;DR;**
+Both setting a static write rate limit and enabling throttling of the write rate can be used to prevent building up an excessive exporting backlog.
+For users, this will be seen as backpressur because processing speed is limited by the rate at which it can write processing results.
 
-Enabling the write rate limiting and throttling makes the processing and exporting speed match and from a user's perspective, the reduced speed is seen as backpressure.
+## Static write limit
 
-## Degraded exporting performance should result in backpressure
+We will construct a cluster under normal utilization and then artificially degrade the exporting process.
+After this we will apply flow control settings to statically rate limit all writes.
+The limit will be set slightly lower than the observed exporting rate.
 
-The new unified flow control introduces a mechanism that rate limits all writes based on the exporting rate. If exporting slows down, writing of new records becomes slower too. For user commands, this will show up as increased backpressure. Internal processing will slow down because the stream processor needs to wait longer for the writing of processing results to complete.
-
-To test this, we will construct a cluster under normal utilization and then artificially degrade the exporting process. After this we will configure the the flow control to rate limit all writes to be on par with the exported records.
-
-For this, we have two possibilities we can enable a static write rate limit or enable throttling that keeps the writes bounded by the exporter backlog. For this we will use the unified control endpoint and configure write rate limit.
+For this we will use the flow control endpoint to temporarily configure the write rate limit.
 
 To fetch the current configuration we can port forward to one of the zeebe pods and use the command:
 ```Shell
@@ -37,31 +40,22 @@ To configure the write rate limit we use the same endpoint, for example:
 ```
 POST /actuator/flowControl
 {
-   "write": {
-        "rampUp": 0,
-        "enabled": true,
-        "limit": 400,
-        "throttling":{
-          "enabled": true,
-          "acceptableBacklog": 100000,
-          "minimumLimit": 100,
-          "resolution": 15
-        }
+  "write": {
+    "enabled": true,
+    "limit": 400
   }
 }
 ```
 
-## Expected
+### Expected
 
-After we artificially degrade the exporting velocity of records we expect to see that the number of queued records increases steadily.
+When we start to degrade the exporting rate, we expect to see the exporting backlog to increase steadily.
 
-For the static limit, we would choose a value slightly lower than the exporting rate (so that the backlog would slowly decrease).
+Once a static write rate limit below the degraded exporting rate is applied, we expect fewer rates and slower processing.
+The exporting backlog should decrease again until we eventually reach zero backlog again.
+Backpressure should increase because processing has slowed down and some requests will be rejected by the write rate limit.
 
-For the throttling of the writes, we would pick a backlog size that would be smaller than the current one to reduce the processing speed. In this case, we would observe both processing speed and exporting speed mach after the acceptable backlog size is reached.
-
-Following the configuration of the write rate limit we should see that the processing of records to gradually start matching the speed of the exporting ones. This means that this will decrease the processing speed and from a user perspective this will be seen as backpressure. We should also observe that the number of records not yet exported decreases, thus bringing both to a balance.
-
-## Actual
+### Actual
 
 After we artificially degrade the exporter performance, we see a constant increase in records not exported since the processing is still happening at the same rate.
 
@@ -79,12 +73,44 @@ As expected we also see this reflected in backpressure that sees the user comman
 
 ![backpressure](backpressure-post-rate-limit.png)
 
-We also observe that the backlog of records not exported starts to decrease at the rate of the difference between exported and processed records.
+We also observe that the backlog of records not exported starts to decrease at the rate of the difference between exported and written records.
 
 ![exporter-backlog-post-rate-limit](number-of-records-not-exported-post-rate-limit.png)
 
+These observations match our expectations and show that a static write rate limit can be used to prevent building up an excessive exporting backlog.
 
-Re-running the same setup, but using the throttling of writes with an acceptable backlog at 100,000  of not exported records, and a limit higher than our processing speed (so has to not impact the this experience), we get the following results: 
+## Dynamic write rate throttling
+
+Choosing a static write rate limit is not a full solution because we can't predict the actual exporting rates.
+To address this, we can enable write rate throttling that will dynamically adjust the write rate based on the exporting backlog and rate.
+
+To enable write rate throttling we can use the flow control endpoint again, for example:
+
+```
+POST /actuator/flowControl
+{
+  "write": {
+    "enabled": true,
+    "limit": 2500,
+    "throttling": {
+      "enabled": true,
+      "acceptableBacklog": 100000,
+      "minimumLimit": 100,
+      "resolution": "15s"
+    }
+  }
+}
+```
+
+### Expected
+
+Similar to the first experiment, we expect to see the exporting backlog increase when we artificially degrade the exporting performance.
+After enabling write rate throttling, we expect that the write rate is reduced significantly and eventually matches the exporting rate.
+The reduced write rate should show up as backpressure.
+Eventually, the exporting backlog settles at the configured acceptable backlog.
+
+### Actual
+Re-running the same setup, but using the throttling of writes with an acceptable backlog at 100,000  of not exported records, and a limit higher than our processing speed (so has to not impact the this experience), we get the following results:
 
 ![number-of-records-not-exported-post-throttling](number-of-records-not-exported-post-throttling.png)
 
@@ -92,7 +118,9 @@ The orange underline metric displays when the throttled write rate is applied.
 
 ![exporting-per-partition-post-throttling](exporting-per-partition-post-throttling.png)
 
-From the panels of the “Exporting per Partition” and “Number of records not exported”, we can observe that during the re-run of the experience our artificially degrading of the exporters only affected Exporters 2 and 3. After we enable throttling, the backlog on these affected exporters starts to decrease as expected, later stabilizing on around 100,000 records. This will drop back to 0 once we remove the artificial degrading of the exporters.
+From the panels of the “Exporting per Partition” and “Number of records not exported”, we can observe that during the re-run of the experience our artificially degrading of the exporters only affected Exporters 2 and 3.
+After we enable throttling, the backlog on these affected exporters starts to decrease as expected, later stabilizing on around 100,000 records.
+This will drop back to 0 once we remove the artificial degrading of the exporters.
 
 ![backpressure-post-throttling](backpressure-post-throttling.png)
 
@@ -100,8 +128,7 @@ In the backpressure, we observe that this increases mostly on the affected parti
 
 ![processing-per-partition-post-throttling](processing-per-partition-post-throttling.png)
 
-Finally, on the panel that shows the processing per partition, we also confirm the expectation that since one of the exporters was not affected by the artificial degrading of the exporter, some additional traffic gets re-routed to this partition, after the throttling gets applied. On the affected partitions we see the processing decreasing slightly in line with the exporting on the same partitions.
+Finally, on the panel that shows the processing per partition, we also confirm the expectation that since one of the exporters was not affected by the artificial degrading of the exporter, some additional traffic gets re-routed to this partition, after the throttling gets applied.
+On the affected partitions we see the processing decreasing slightly in line with the exporting on the same partitions.
 
-
-Overall the observations match our expectations and show that the write rate limiter and write rate throttling both succeed in matching the processing and exporting speed through different mechanisms and translating this into backpressure to the user.
-
+Overall the observations match our expectations and show that write rate throttling succeeds and keeps exporting backlog limited.

--- a/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
+++ b/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
@@ -18,7 +18,7 @@ In these experiments, we will test both ways of limiting the write rate and obse
 
 **TL;DR;**
 Both setting a static write rate limit and enabling throttling of the write rate can be used to prevent building up an excessive exporting backlog.
-For users, this will be seen as backpressur because processing speed is limited by the rate at which it can write processing results.
+For users, this will be seen as backpressure because processing speed is limited by the rate at which it can write processing results.
 
 ## Static write limit
 
@@ -33,7 +33,7 @@ To fetch the current configuration we can port forward to one of the zeebe pods 
 GET /actuator/flowControl
 ```
 
-![original-configurtion](original-configuration.png)
+![original-configuration](original-configuration.png)
 
 To configure the write rate limit we use the same endpoint, for example:
 
@@ -110,7 +110,7 @@ The reduced write rate should show up as backpressure.
 Eventually, the exporting backlog settles at the configured acceptable backlog.
 
 ### Actual
-Re-running the same setup, but using the throttling of writes with an acceptable backlog at 100,000  of not exported records, and a limit higher than our processing speed (so has to not impact the this experience), we get the following results:
+Re-running the same setup, but using the throttling of writes with an acceptable backlog at 100,000  of not exported records, and a limit higher than our processing speed (so has to not impact the experience), we get the following results:
 
 ![number-of-records-not-exported-post-throttling](number-of-records-not-exported-post-throttling.png)
 


### PR DESCRIPTION
This is a slight restructuring and a couple of suggested improvements on top of https://github.com/zeebe-io/zeebe-chaos/pull/535.

1. Use dedicated sections for both experiments instead of mixing them in one.
2. Adjust the example configs to configure only what's needed for each experiment
3. Formatting: newlines after each sentence.
4. Wording: Some general rewording to improve clarity.

I thought opening a PR with suggested improvements is easier than leaving review comments.
If you accept this PR, please apply the same for the second blog post.
