### PR TITLE
docs: truncate posts

### DIFF
--- a/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
+++ b/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-bottlenecked-exporting/index.md
@@ -20,6 +20,7 @@ In these experiments, we will test both ways of limiting the write rate and obse
 Both setting a static write rate limit and enabling throttling of the write rate can be used to prevent building up an excessive exporting backlog.
 For users, this will be seen as backpressure because processing speed is limited by the rate at which it can write processing results.
 
+<!--truncate-->
 ## Static write limit
 
 We will construct a cluster under normal utilization and then artificially degrade the exporting process.

--- a/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-uncontrolled-process-loops/index.md
+++ b/chaos-days/blog/2024-07-25-Using-flow-control-to-handle-uncontrolled-process-loops/index.md
@@ -27,6 +27,7 @@ Enabling the write rate limiting can help mitigate the effects caused by
 process instances that contain uncontrolled loops by preventing building up an 
 excessive exporting backlog. 
 
+<!--truncate-->
 ## Mitigating the performance impacts of deployed loops:
 
 When an uncontrolled loop is accidentally deployed this tends to use of 


### PR DESCRIPTION
Hey @rodrigo-lourenco-lopes just want to let you know that I added some truncation (would be nice if you could add this on your next post :)) I normally cut after the TL;DR.

This allows to have a nice short view of the blog post in the overview section :)

I did a short screencast of it:

**Without**

![without](https://github.com/user-attachments/assets/aa700c3f-83c5-408d-8efa-f22bf0341b65)

**With truncation**

![with](https://github.com/user-attachments/assets/db742154-54d1-4726-8491-f20e5e847c4e)


I will go ahead and merge it, I just wanted to let you know :) Thanks again for writing these posts 🚀 