### PR TITLE
Connect deployed workers to cluster using oauth credentials

### DIFF
--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -22,6 +22,7 @@ spec:
             - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dapp.brokerUrl=http://zeebe-service:26500
+                -Dapp.auth.type=OAUTH
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=10
                 -Dapp.worker.pollingDelay={{.PollingDelay}}


### PR DESCRIPTION
Deployed workers should use oauth credentials. Most of this is already configured like the env vars `CAMUNDA_CLIENT_ID` and such. However, without specifying the auth type, the client will assume the default NoopCredentialsProvider.

For more details of this change, refer to:
- https://camunda.slack.com/archives/C099TR7MS02/p1755511141765679

For an analysis of the current behavior before this change, refer to:
- https://camunda.slack.com/archives/C099TR7MS02/p1755510759910159