### PR TITLE
fix: updated the go release.yaml version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
         default: 'zbchaos-v1.X.0'
 
 env:
-  GO_VERSION: 1.25
+  GO_VERSION: 1.26
 
 jobs:
  go-release:


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration, specifically updating the Go version used in the release process from 1.25 to 1.26.

* Updated the `GO_VERSION` environment variable in `.github/workflows/release.yaml` from `1.25` to `1.26` to ensure the release workflow uses the latest Go version.