### PR TITLE
fix: rename worker env vars to ZEEBE_* form

### DIFF
--- a/go-chaos/internal/deployment_test.go
+++ b/go-chaos/internal/deployment_test.go
@@ -355,8 +355,8 @@ func Test_ShouldRenderSpringBootEnvVarsForSelfManaged(t *testing.T) {
 
 	envs := deploymentList.Items[0].Spec.Template.Spec.Containers[0].Env
 	assert.Equal(t, "worker", envValue(envs, "SPRING_PROFILES_ACTIVE"))
-	assert.Equal(t, "http://sm-gateway-service:26500", envValue(envs, "CAMUNDA_CLIENT_GRPC_ADDRESS"))
-	assert.Equal(t, "http://sm-gateway-service:8080", envValue(envs, "CAMUNDA_CLIENT_REST_ADDRESS"))
+	assert.Equal(t, "http://sm-gateway-service:26500", envValue(envs, "ZEEBE_GRPC_ADDRESS"))
+	assert.Equal(t, "http://sm-gateway-service:8080", envValue(envs, "ZEEBE_REST_ADDRESS"))
 	assert.Equal(t, "false", envValue(envs, "CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC"))
 	assert.Equal(t, "62s", envValue(envs, "CAMUNDA_CLIENT_REQUEST_TIMEOUT"))
 	assert.Equal(t, "10", envValue(envs, "LOAD_TESTER_WORKER_CAPACITY"))
@@ -364,8 +364,9 @@ func Test_ShouldRenderSpringBootEnvVarsForSelfManaged(t *testing.T) {
 	assert.Equal(t, "50ms", envValue(envs, "LOAD_TESTER_WORKER_COMPLETION_DELAY"))
 
 	// Auth via CAMUNDA_CLIENT_AUTH_* (relaxed-binds to camunda.client.auth.* on the starter).
+	// while the audience is provided via ZEEBE_TOKEN_AUDIENCE.
 	assert.Equal(t, "AuthServer", envValue(envs, "CAMUNDA_CLIENT_AUTH_TOKEN_URL"))
-	assert.Equal(t, "Audience", envValue(envs, "CAMUNDA_CLIENT_AUTH_AUDIENCE"))
+	assert.Equal(t, "Audience", envValue(envs, "ZEEBE_TOKEN_AUDIENCE"))
 	assert.Equal(t, "ClientId", envValue(envs, "CAMUNDA_CLIENT_AUTH_CLIENT_ID"))
 	assert.Equal(t, "SuperSecret", envValue(envs, "CAMUNDA_CLIENT_AUTH_CLIENT_SECRET"))
 	assert.Equal(t, "oidc", envValue(envs, "CAMUNDA_CLIENT_AUTH_METHOD"))

--- a/go-chaos/internal/manifests/worker.yaml
+++ b/go-chaos/internal/manifests/worker.yaml
@@ -34,7 +34,7 @@ spec:
               value: "debug"
             - name: CAMUNDA_CLIENT_AUTH_TOKEN_URL
               value: {{.AuthServer}}
-            - name: CAMUNDA_CLIENT_AUTH_AUDIENCE
+            - name: ZEEBE_TOKEN_AUDIENCE
               value: {{.Audience}}
             - name: CAMUNDA_CLIENT_AUTH_CLIENT_ID
               value: {{.ClientId}}
@@ -44,9 +44,9 @@ spec:
               value: "worker"
             - name: CAMUNDA_CLIENT_AUTH_METHOD
               value: {{if .AuthServer}}"oidc"{{else}}"none"{{end}}
-            - name: CAMUNDA_CLIENT_GRPC_ADDRESS
+            - name: ZEEBE_GRPC_ADDRESS
               value: http://{{.ServiceName}}:26500
-            - name: CAMUNDA_CLIENT_REST_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               value: http://{{.ServiceName}}:8080
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
               value: "false"


### PR DESCRIPTION
## Context

The previous worker.yaml config still fails on 8.7 because the property names there use a different format than 8.8+. I verified this by deploying into an 8.7 namespace and confirmed that switching to the env var names below resolves it.

## Change

Rename the affected env vars in `worker.yaml` so the same manifest works across 8.7 and 8.8+:

- `CAMUNDA_CLIENT_GRPC_ADDRESS` → `ZEEBE_GRPC_ADDRESS`
- `CAMUNDA_CLIENT_REST_ADDRESS` → `ZEEBE_REST_ADDRESS` (not used in 8.7, but kept consistent)
- `CAMUNDA_CLIENT_AUDIENCE` → `ZEEBE_TOKEN_AUDIENCE`


For 8.7, it uses the following property to resolve `_ZEEBE_` is added as a extra param in between:
- 'CAMUNDA_CLIENT_ZEEBE_GRPC_ADDRESS`

Test assertions updated accordingly.