### PR TITLE
fix: increase cluster wait timeout and fix stale error message

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -295,8 +295,9 @@ func portForwardAndWaitForChange(flags *Flags) error {
 	port, closePortForward := k8Client.MustGatewayPortForward(0, 9600)
 	defer closePortForward()
 
-	// Wait for shorter time. Retry and longer timeout can be configured in the chaos experiment description
-	timeout := time.Minute * 5
+	// Allow enough time for large Raft snapshot transfers during data-loss recovery.
+	// Retries and a longer overall budget can be configured in the chaos experiment description.
+	timeout := time.Minute * 15
 	return waitForChange(port, flags.changeId, timeout)
 }
 
@@ -342,7 +343,7 @@ func waitForChange(port int, changeId int64, timeout time.Duration) error {
 		time.Sleep(interval)
 	}
 
-	return fmt.Errorf("change %d did not complete within 25 minutes", changeId)
+	return fmt.Errorf("change %d did not complete within %s", changeId, timeout)
 }
 
 func forceFailover(flags *Flags) error {


### PR DESCRIPTION
## Summary

- Increases the `cluster wait` timeout from 5 to 15 minutes to handle Raft snapshot transfer/installation during data-loss recovery in long-running test loops. In the `2-region-dataloss-failover` test, brokers that recover after data loss must transfer a full Raft snapshot per partition; with 7+ hours of accumulated state this can exceed 5 minutes per partition, causing 3 sequential `PartitionJoin` ops to run past the previous limit.
- Fixes the stale error message in `waitForChange` that always reported "25 minutes" regardless of the actual timeout passed by the caller.

## Context

Investigated as part of INC-5932 — `2-region-dataloss-failover` e2e multiregion test failing in loop 5 after 7.5 hours of runtime. `cluster wait` exhausted its retry budget (3 × 5 min = 15 min) before Change 36 (12 ops) completed. Root cause: large RocksDB snapshots from accumulated state made `PartitionJoin` ops slow, not a Zeebe engine regression.

Closes #854

## Test plan

- [ ] Verify `go build ./cmd/...` passes (done locally)
- [ ] Re-run `2-region-dataloss-failover` e2e test to confirm loop 5 no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)