### PR TITLE
blog: fix README, add Make shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 chaostoolkit.log
 journal.json
 
+go-chaos/go-chaos
 
 target/
 .classpath

--- a/chaos-days/Makefile
+++ b/chaos-days/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all install build serve
+
+all: install serve
+
+# Install the tools and dependencies
+install:
+	npm install
+
+# Builds the final website
+build:
+	npm run -- build
+
+# Builds the website + automatically rebuilds + reloads the web browser
+serve:
+	npm run -- start

--- a/chaos-days/README.md
+++ b/chaos-days/README.md
@@ -1,25 +1,25 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
 ### Installation
 
-```
-$ npm install
+```shell
+make install
 ```
 
 ### Local Development
 
-```
-$ npm run serve
+```shell
+make serve
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
-```
-$ npm run build
+```shell
+make build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.


### PR DESCRIPTION
`npm run serve` only starts the webserver to serve the local `build` directory: it doesn't build and doesn't rebuild on code change. [`npm run start` does](https://docusaurus.io/docs/installation#running-the-development-server) though.

Hide this behind Makefile targets to make it easier to start with.