### PR TITLE
build: use Renovate native automerge instead of custom merge job

### DIFF
--- a/.github/workflows/buildChaosBlog.yml
+++ b/.github/workflows/buildChaosBlog.yml
@@ -27,18 +27,3 @@ jobs:
         run: |
           cd chaos-days
           npm run build
-  auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    if: github.repository == 'camunda/zeebe-chaos' && (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')
-    permissions:
-      checks: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - id: merge
-        name: Merge PR
-        run: gh pr merge ${{ github.event.pull_request.number }} --merge
-        env:
-          GITHUB_TOKEN: "${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}"

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -40,18 +40,3 @@ jobs:
       run: make checkLicense
     - name: Run Go Tests
       run: make test
-  auto-merge:
-    name: Auto-merge dependabot PRs
-    runs-on: ubuntu-latest
-    needs: [ go-ci ]
-    if: github.repository == 'camunda/zeebe-chaos' && (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')
-    permissions:
-      checks: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - id: merge
-        name: Merge PR
-        run: gh pr merge ${{ github.event.pull_request.number }} --merge
-        env:
-          GITHUB_TOKEN: "${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}"

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:recommended"
   ],
+  "automerge": true,
+  "platformAutomerge": true,
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
## Summary
- Enables Renovate's native automerge (`automerge` + `platformAutomerge`) for all dependency updates, so Renovate PRs merge automatically via GitHub's built-in auto-merge once required checks pass.
- Removes the hand-rolled `auto-merge` job from `buildChaosBlog.yml` and `go-ci.yml`, which shelled out to `gh pr merge` using the `AUTO_MERGE_GITHUB_TOKEN` secret. That secret can now be removed from repo settings if unused elsewhere.

## Why
Renovate PR [#577](https://github.com/camunda/zeebe-chaos/pull/577) sat unmerged for months with a red "Build the documentation" check and no automerge, because Renovate's own automerge was off for regular updates and the custom job only merges when the actor is `dependabot[bot]`/`renovate[bot]` - a human-authored fix commit doesn't qualify. Native automerge is the standard Renovate pattern and removes the extra PAT-based workflow entirely.

## Follow-up needed (not in this PR)
This only takes effect once `main`'s branch protection requires the relevant status checks (`Build the documentation`, `Run Go CI`) - otherwise GitHub's native auto-merge has nothing to wait on and merges immediately. Also requires the repo setting **"Allow auto-merge"** to be enabled (Settings → General → Pull Requests).

## Test plan
- [ ] Confirm `Build the documentation` and `Run Go CI` are set as required status checks on `main`
- [ ] Confirm "Allow auto-merge" is enabled for the repo
- [ ] Verify a subsequent Renovate PR auto-merges once checks pass
- [ ] Remove the now-unused `AUTO_MERGE_GITHUB_TOKEN` secret, if not used elsewhere
