### PR TITLE
fix: required status checks never report for path-filtered PRs

### DIFF
--- a/.github/workflows/buildChaosBlog.yml
+++ b/.github/workflows/buildChaosBlog.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - chaos-days/**
       - .github/workflows/buildChaosBlog.yml
+  pull_request:
+    paths:
+      - chaos-days/**
+      - .github/workflows/buildChaosBlog.yml
 
 jobs:
   build:

--- a/.github/workflows/buildChaosBlog.yml
+++ b/.github/workflows/buildChaosBlog.yml
@@ -8,10 +8,7 @@ on:
     paths:
       - chaos-days/**
       - .github/workflows/buildChaosBlog.yml
-  pull_request:
-    paths:
-      - chaos-days/**
-      - .github/workflows/buildChaosBlog.yml
+  pull_request: { }
 
 jobs:
   build:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -3,10 +3,7 @@ name: Go CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    paths: 
-      - go-chaos/**
-      - .github/workflows/go-ci.yml
+  pull_request: { }
 
 env:
   GO_VERSION: 1.26


### PR DESCRIPTION
## Summary
- Drops the `paths` filter from the `pull_request` trigger on both `buildChaosBlog.yml` and `go-ci.yml`, so `Build the documentation` and `Run Go CI` run unconditionally on every PR.

## Why
Follow-up to #898. `main`'s branch protection requires both `Build the documentation` and `Run Go CI` (classic branch protection, `strict: true`). Both workflows only ran their `pull_request` trigger when the diff matched a `paths` filter (`chaos-days/**` / `go-chaos/**`). Classic required status checks do **not** auto-pass when a path-filtered workflow doesn't match - GitHub simply never posts a check for that context, and the PR sits at `mergeable_state: unstable` forever.

Verified directly on this PR's own head commit (which only touched `buildChaosBlog.yml`, not `go-chaos/**`): `Run Go CI` never got a check run at all. An earlier version of this fix added a path-filtered `pull_request` trigger to `buildChaosBlog.yml` alone, which had the exact same latent bug - it only "worked" here because this PR happens to touch the workflow file itself, which was in that filter.

## Test plan
- [ ] Confirm both `Build the documentation` and `Run Go CI` report on this PR's head commit
- [ ] Confirm `mergeable_state` moves from `unstable` to `clean`
- [ ] Verify a subsequent Renovate PR (that touches neither `chaos-days/**` nor `go-chaos/**`, e.g. a root-level config bump) still gets both checks reported and auto-merges